### PR TITLE
Plan 3: Components V2 first-class category

### DIFF
--- a/packages/mcp-core/src/resources/components-v2.test.ts
+++ b/packages/mcp-core/src/resources/components-v2.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { listV2Resources, readV2Resource } from './components-v2.js';
+
+describe('Components V2 MCP resources', () => {
+  it('listV2Resources returns 5 templates + 1 schema = 6 resources', async () => {
+    const resources = await listV2Resources();
+    expect(resources.length).toBe(6);
+    expect(resources.map((r) => r.uri)).toContain('discord://components-v2/templates/announcement');
+    expect(resources.map((r) => r.uri)).toContain('discord://components-v2/schema');
+  });
+
+  it('readV2Resource returns template JSON for a known URI', async () => {
+    const r = await readV2Resource('discord://components-v2/templates/welcome_card');
+    expect(r).not.toBeNull();
+    expect(r!.mimeType).toBe('application/json');
+    const parsed = JSON.parse(r!.text);
+    expect(parsed.name).toBe('welcome_card');
+    expect(Array.isArray(parsed.components)).toBe(true);
+  });
+
+  it('readV2Resource returns the schema as JSON Schema for the schema URI', async () => {
+    const r = await readV2Resource('discord://components-v2/schema');
+    expect(r).not.toBeNull();
+    const parsed = JSON.parse(r!.text);
+    // The schema export is a JSON Schema fragment describing ComponentsV2Array.
+    // Look for any of: type "array", or oneOf/anyOf at the top level (zod 4 emits union as anyOf typically).
+    const hasArrayShape = parsed.type === 'array' || parsed.items !== undefined;
+    const hasUnionShape = Array.isArray(parsed.oneOf) || Array.isArray(parsed.anyOf);
+    expect(hasArrayShape || hasUnionShape).toBe(true);
+  });
+
+  it('readV2Resource returns null for an unknown URI', async () => {
+    const r = await readV2Resource('discord://components-v2/templates/does_not_exist');
+    expect(r).toBeNull();
+  });
+
+  it('readV2Resource returns null for a malformed URI', async () => {
+    const r = await readV2Resource('not-a-discord-uri');
+    expect(r).toBeNull();
+  });
+});

--- a/packages/mcp-core/src/resources/components-v2.test.ts
+++ b/packages/mcp-core/src/resources/components-v2.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { listV2Resources, readV2Resource } from './components-v2.js';
 
 describe('Components V2 MCP resources', () => {

--- a/packages/mcp-core/src/resources/components-v2.ts
+++ b/packages/mcp-core/src/resources/components-v2.ts
@@ -1,0 +1,68 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { dirname, join, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+import { ComponentsV2Array } from '../tools/components-v2/_lib/schema.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const TEMPLATES_DIR = join(__dirname, '..', 'tools', 'components-v2', 'templates');
+
+const SCHEMA_URI = 'discord://components-v2/schema';
+const TEMPLATE_URI_PREFIX = 'discord://components-v2/templates/';
+
+export interface V2ResourceEntry {
+  readonly uri: string;
+  readonly name: string;
+  readonly description: string;
+  readonly mimeType: string;
+}
+
+export interface V2ResourceContent {
+  readonly uri: string;
+  readonly mimeType: string;
+  readonly text: string;
+}
+
+export async function listV2Resources(): Promise<readonly V2ResourceEntry[]> {
+  const files = await readdir(TEMPLATES_DIR);
+  const templates = files
+    .filter((f) => f.endsWith('.json'))
+    .sort()
+    .map((f) => {
+      const name = basename(f, '.json');
+      return {
+        uri: `${TEMPLATE_URI_PREFIX}${name}`,
+        name: `Components V2 template — ${name}`,
+        description: `Pre-built Components V2 layout for ${name}. Apply via components_v2_send_from_template.`,
+        mimeType: 'application/json',
+      };
+    });
+  return [
+    {
+      uri: SCHEMA_URI,
+      name: 'Components V2 JSON Schema',
+      description: 'JSON Schema (draft-2020-12) for the Components V2 component types.',
+      mimeType: 'application/json',
+    },
+    ...templates,
+  ];
+}
+
+export async function readV2Resource(uri: string): Promise<V2ResourceContent | null> {
+  if (uri === SCHEMA_URI) {
+    const json = z.toJSONSchema(ComponentsV2Array, { target: 'draft-2020-12' });
+    return { uri, mimeType: 'application/json', text: JSON.stringify(json, null, 2) };
+  }
+  if (uri.startsWith(TEMPLATE_URI_PREFIX)) {
+    const name = uri.slice(TEMPLATE_URI_PREFIX.length);
+    if (!/^[a-z][a-z0-9_]*$/.test(name)) return null;
+    try {
+      const text = await readFile(join(TEMPLATES_DIR, `${name}.json`), 'utf8');
+      return { uri, mimeType: 'application/json', text };
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}

--- a/packages/mcp-core/src/resources/components-v2.ts
+++ b/packages/mcp-core/src/resources/components-v2.ts
@@ -1,5 +1,5 @@
-import { readFile, readdir } from 'node:fs/promises';
-import { dirname, join, basename } from 'node:path';
+import { readdir, readFile } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import { ComponentsV2Array } from '../tools/components-v2/_lib/schema.js';

--- a/packages/mcp-core/src/server.contract.test.ts
+++ b/packages/mcp-core/src/server.contract.test.ts
@@ -81,9 +81,9 @@ describe('MCP protocol contract', () => {
     expect(text).toMatch(/channel_id/);
   });
 
-  it('lists 15 tools after auto-discovery (Plan 0+1+2 cumulative)', async () => {
+  it('lists 18 tools after auto-discovery (Plan 0+1+2+3D cumulative)', async () => {
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(15);
+    expect(tools.length).toBe(18);
     const names = new Set(tools.map((t) => t.name));
     for (const expected of [
       'messages_send',
@@ -101,6 +101,9 @@ describe('MCP protocol contract', () => {
       'events_list',
       'commands_list_guild',
       'users_get_current',
+      'components_v2_build_container',
+      'components_v2_build_section',
+      'components_v2_build_media_gallery',
     ]) {
       expect(names.has(expected)).toBe(true);
     }

--- a/packages/mcp-core/src/server.contract.test.ts
+++ b/packages/mcp-core/src/server.contract.test.ts
@@ -81,9 +81,9 @@ describe('MCP protocol contract', () => {
     expect(text).toMatch(/channel_id/);
   });
 
-  it('lists 18 tools after auto-discovery (Plan 0+1+2+3D cumulative)', async () => {
+  it('lists 22 tools after auto-discovery (Plan 0+1+2+3D+3E cumulative)', async () => {
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(18);
+    expect(tools.length).toBe(22);
     const names = new Set(tools.map((t) => t.name));
     for (const expected of [
       'messages_send',
@@ -104,6 +104,10 @@ describe('MCP protocol contract', () => {
       'components_v2_build_container',
       'components_v2_build_section',
       'components_v2_build_media_gallery',
+      'components_v2_validate',
+      'components_v2_preview',
+      'components_v2_send',
+      'components_v2_edit',
     ]) {
       expect(names.has(expected)).toBe(true);
     }

--- a/packages/mcp-core/src/server.contract.test.ts
+++ b/packages/mcp-core/src/server.contract.test.ts
@@ -81,9 +81,9 @@ describe('MCP protocol contract', () => {
     expect(text).toMatch(/channel_id/);
   });
 
-  it('lists 22 tools after auto-discovery (Plan 0+1+2+3D+3E cumulative)', async () => {
+  it('lists 23 tools after auto-discovery (Plan 0+1+2+3D+3E+3F cumulative)', async () => {
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(22);
+    expect(tools.length).toBe(23);
     const names = new Set(tools.map((t) => t.name));
     for (const expected of [
       'messages_send',
@@ -108,6 +108,7 @@ describe('MCP protocol contract', () => {
       'components_v2_preview',
       'components_v2_send',
       'components_v2_edit',
+      'components_v2_send_from_template',
     ]) {
       expect(names.has(expected)).toBe(true);
     }

--- a/packages/mcp-core/src/server.contract.test.ts
+++ b/packages/mcp-core/src/server.contract.test.ts
@@ -122,4 +122,21 @@ describe('MCP protocol contract', () => {
     expect(r.isError).toBe(true);
     expect(r.structuredContent).toMatchObject({ code: 'DRY_RUN_PREVIEW', tool: 'messages_delete' });
   });
+
+  it('lists 6 V2 resources via MCP resources/list', async () => {
+    const { resources } = await client.listResources();
+    expect(resources.length).toBe(6);
+    expect(resources.map((r) => r.uri)).toContain('discord://components-v2/templates/announcement');
+    expect(resources.map((r) => r.uri)).toContain('discord://components-v2/schema');
+  });
+
+  it('reads V2 announcement template via resources/read', async () => {
+    const r = await client.readResource({ uri: 'discord://components-v2/templates/announcement' });
+    expect(r.contents).toHaveLength(1);
+    const c = r.contents[0]!;
+    expect(c.mimeType).toBe('application/json');
+    const text = c.text as string;
+    const parsed = JSON.parse(text);
+    expect(parsed.name).toBe('announcement');
+  });
 });

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -23,6 +23,7 @@ import { ToolStore } from './stores/ToolStore.js';
 import AuditLogGet from './tools/audit_log/get.js';
 import ChannelsGet from './tools/channels/get.js';
 import ComponentsV2BuildContainer from './tools/components-v2/build_container.js';
+import ComponentsV2BuildSection from './tools/components-v2/build_section.js';
 import ChannelsList from './tools/channels/list.js';
 import CommandsListGuild from './tools/commands/list_guild.js';
 import EventsList from './tools/events/list.js';
@@ -111,6 +112,10 @@ export async function buildServer(deps: BuildServerDeps): Promise<BuildServerRes
   await toolStore.loadPiece({
     name: 'components_v2_build_container',
     piece: ComponentsV2BuildContainer as unknown as ConcreteTool,
+  });
+  await toolStore.loadPiece({
+    name: 'components_v2_build_section',
+    piece: ComponentsV2BuildSection as unknown as ConcreteTool,
   });
   await toolStore.loadAll();
 

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -25,6 +25,10 @@ import ChannelsGet from './tools/channels/get.js';
 import ComponentsV2BuildContainer from './tools/components-v2/build_container.js';
 import ComponentsV2BuildMediaGallery from './tools/components-v2/build_media_gallery.js';
 import ComponentsV2BuildSection from './tools/components-v2/build_section.js';
+import ComponentsV2Edit from './tools/components-v2/edit.js';
+import ComponentsV2PreviewTool from './tools/components-v2/preview-tool.js';
+import ComponentsV2Send from './tools/components-v2/send.js';
+import ComponentsV2Validate from './tools/components-v2/validate.js';
 import ChannelsList from './tools/channels/list.js';
 import CommandsListGuild from './tools/commands/list_guild.js';
 import EventsList from './tools/events/list.js';
@@ -121,6 +125,22 @@ export async function buildServer(deps: BuildServerDeps): Promise<BuildServerRes
   await toolStore.loadPiece({
     name: 'components_v2_build_media_gallery',
     piece: ComponentsV2BuildMediaGallery as unknown as ConcreteTool,
+  });
+  await toolStore.loadPiece({
+    name: 'components_v2_validate',
+    piece: ComponentsV2Validate as unknown as ConcreteTool,
+  });
+  await toolStore.loadPiece({
+    name: 'components_v2_preview',
+    piece: ComponentsV2PreviewTool as unknown as ConcreteTool,
+  });
+  await toolStore.loadPiece({
+    name: 'components_v2_send',
+    piece: ComponentsV2Send as unknown as ConcreteTool,
+  });
+  await toolStore.loadPiece({
+    name: 'components_v2_edit',
+    piece: ComponentsV2Edit as unknown as ConcreteTool,
   });
   await toolStore.loadAll();
 

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -5,8 +5,8 @@ import {
   CallToolRequestSchema,
   ListResourcesRequestSchema,
   ListToolsRequestSchema,
-  ReadResourceRequestSchema,
   type Tool as McpTool,
+  ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { container } from '@sapphire/pieces';
 import type { Logger } from 'pino';
@@ -20,20 +20,21 @@ import { validateMiddleware } from './middleware/validate.js';
 import type { Tool } from './pieces/Tool.js';
 import { CategoryEnabled } from './preconditions/CategoryEnabled.js';
 import { ConfirmRequired } from './preconditions/ConfirmRequired.js';
+import { listV2Resources, readV2Resource } from './resources/components-v2.js';
 import { PreconditionStore } from './stores/PreconditionStore.js';
 import { ToolStore } from './stores/ToolStore.js';
 import AuditLogGet from './tools/audit_log/get.js';
 import ChannelsGet from './tools/channels/get.js';
+import ChannelsList from './tools/channels/list.js';
+import CommandsListGuild from './tools/commands/list_guild.js';
 import ComponentsV2BuildContainer from './tools/components-v2/build_container.js';
 import ComponentsV2BuildMediaGallery from './tools/components-v2/build_media_gallery.js';
 import ComponentsV2BuildSection from './tools/components-v2/build_section.js';
 import ComponentsV2Edit from './tools/components-v2/edit.js';
-import ComponentsV2SendFromTemplate from './tools/components-v2/send-from-template.js';
 import ComponentsV2PreviewTool from './tools/components-v2/preview-tool.js';
 import ComponentsV2Send from './tools/components-v2/send.js';
+import ComponentsV2SendFromTemplate from './tools/components-v2/send-from-template.js';
 import ComponentsV2Validate from './tools/components-v2/validate.js';
-import ChannelsList from './tools/channels/list.js';
-import CommandsListGuild from './tools/commands/list_guild.js';
 import EventsList from './tools/events/list.js';
 import GuildGet from './tools/guild/get.js';
 import MembersGet from './tools/members/get.js';
@@ -45,7 +46,6 @@ import MessagesSend from './tools/messages/send.js';
 import RolesList from './tools/roles/list.js';
 import UsersGetCurrent from './tools/users/get_current.js';
 import WebhooksListChannel from './tools/webhooks/list_channel.js';
-import { listV2Resources, readV2Resource } from './resources/components-v2.js';
 
 export interface BuildServerDeps {
   rest: REST;

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -3,7 +3,9 @@ import type { REST } from '@discordjs/rest';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   CallToolRequestSchema,
+  ListResourcesRequestSchema,
   ListToolsRequestSchema,
+  ReadResourceRequestSchema,
   type Tool as McpTool,
 } from '@modelcontextprotocol/sdk/types.js';
 import { container } from '@sapphire/pieces';
@@ -43,6 +45,7 @@ import MessagesSend from './tools/messages/send.js';
 import RolesList from './tools/roles/list.js';
 import UsersGetCurrent from './tools/users/get_current.js';
 import WebhooksListChannel from './tools/webhooks/list_channel.js';
+import { listV2Resources, readV2Resource } from './resources/components-v2.js';
 
 export interface BuildServerDeps {
   rest: REST;
@@ -177,7 +180,7 @@ export async function buildServer(deps: BuildServerDeps): Promise<BuildServerRes
   const server = new Server(
     { name: 'discord-mcp', version: '0.0.0' },
     {
-      capabilities: { tools: {} },
+      capabilities: { tools: {}, resources: {} },
       instructions:
         'Discord MCP server. v0/Plan-1 — only messages_send available. ' +
         'Errors return structured CallToolResult with code/retriable/recovery_hint fields. ' +
@@ -237,6 +240,21 @@ export async function buildServer(deps: BuildServerDeps): Promise<BuildServerRes
       deps.logger.warn({ err: e, tool: tool.name, requestId }, 'tool error');
       return formatErrorForUser(e, { toolName: tool.name, transport: 'stdio' });
     }
+  });
+
+  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    const resources = await listV2Resources();
+    return { resources: resources.map((r) => ({ ...r })) };
+  });
+
+  server.setRequestHandler(ReadResourceRequestSchema, async (req) => {
+    const content = await readV2Resource(req.params.uri);
+    if (content === null) {
+      throw new Error(`Resource not found: ${req.params.uri}`);
+    }
+    return {
+      contents: [{ uri: content.uri, mimeType: content.mimeType, text: content.text }],
+    };
   });
 
   return { server, registeredTools, registeredPreconditions };

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -26,6 +26,7 @@ import ComponentsV2BuildContainer from './tools/components-v2/build_container.js
 import ComponentsV2BuildMediaGallery from './tools/components-v2/build_media_gallery.js';
 import ComponentsV2BuildSection from './tools/components-v2/build_section.js';
 import ComponentsV2Edit from './tools/components-v2/edit.js';
+import ComponentsV2SendFromTemplate from './tools/components-v2/send-from-template.js';
 import ComponentsV2PreviewTool from './tools/components-v2/preview-tool.js';
 import ComponentsV2Send from './tools/components-v2/send.js';
 import ComponentsV2Validate from './tools/components-v2/validate.js';
@@ -141,6 +142,10 @@ export async function buildServer(deps: BuildServerDeps): Promise<BuildServerRes
   await toolStore.loadPiece({
     name: 'components_v2_edit',
     piece: ComponentsV2Edit as unknown as ConcreteTool,
+  });
+  await toolStore.loadPiece({
+    name: 'components_v2_send_from_template',
+    piece: ComponentsV2SendFromTemplate as unknown as ConcreteTool,
   });
   await toolStore.loadAll();
 

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -22,6 +22,7 @@ import { PreconditionStore } from './stores/PreconditionStore.js';
 import { ToolStore } from './stores/ToolStore.js';
 import AuditLogGet from './tools/audit_log/get.js';
 import ChannelsGet from './tools/channels/get.js';
+import ComponentsV2BuildContainer from './tools/components-v2/build_container.js';
 import ChannelsList from './tools/channels/list.js';
 import CommandsListGuild from './tools/commands/list_guild.js';
 import EventsList from './tools/events/list.js';
@@ -106,6 +107,10 @@ export async function buildServer(deps: BuildServerDeps): Promise<BuildServerRes
   await toolStore.loadPiece({
     name: 'users_get_current',
     piece: UsersGetCurrent as unknown as ConcreteTool,
+  });
+  await toolStore.loadPiece({
+    name: 'components_v2_build_container',
+    piece: ComponentsV2BuildContainer as unknown as ConcreteTool,
   });
   await toolStore.loadAll();
 

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -23,6 +23,7 @@ import { ToolStore } from './stores/ToolStore.js';
 import AuditLogGet from './tools/audit_log/get.js';
 import ChannelsGet from './tools/channels/get.js';
 import ComponentsV2BuildContainer from './tools/components-v2/build_container.js';
+import ComponentsV2BuildMediaGallery from './tools/components-v2/build_media_gallery.js';
 import ComponentsV2BuildSection from './tools/components-v2/build_section.js';
 import ChannelsList from './tools/channels/list.js';
 import CommandsListGuild from './tools/commands/list_guild.js';
@@ -116,6 +117,10 @@ export async function buildServer(deps: BuildServerDeps): Promise<BuildServerRes
   await toolStore.loadPiece({
     name: 'components_v2_build_section',
     piece: ComponentsV2BuildSection as unknown as ConcreteTool,
+  });
+  await toolStore.loadPiece({
+    name: 'components_v2_build_media_gallery',
+    piece: ComponentsV2BuildMediaGallery as unknown as ConcreteTool,
   });
   await toolStore.loadAll();
 

--- a/packages/mcp-core/src/tools/components-v2/_lib/interpolate.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/interpolate.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { interpolateTemplate } from './interpolate.js';
+
+describe('interpolateTemplate', () => {
+  it('substitutes {{var}} in string fields', () => {
+    const out = interpolateTemplate({ a: 'hello {{name}}!' }, { name: 'world' });
+    expect(out).toEqual({ a: 'hello world!' });
+  });
+
+  it('recurses into nested objects + arrays', () => {
+    const out = interpolateTemplate(
+      { type: 17, components: [{ type: 10, content: 'v{{ver}}' }] },
+      { ver: '1.0' },
+    );
+    expect((out as { components: Array<{ content: string }> }).components[0]!.content).toBe('v1.0');
+  });
+
+  it('leaves missing variables as the literal placeholder', () => {
+    const out = interpolateTemplate({ a: '{{missing}}' }, {});
+    expect(out).toEqual({ a: '{{missing}}' });
+  });
+
+  it('handles multiple variables in one string', () => {
+    const out = interpolateTemplate({ a: '{{x}} and {{y}}' }, { x: 'A', y: 'B' });
+    expect(out).toEqual({ a: 'A and B' });
+  });
+
+  it('does not interpolate non-string values', () => {
+    const out = interpolateTemplate({ n: 42, flag: true, arr: [1, 2] }, { x: 'A' });
+    expect(out).toEqual({ n: 42, flag: true, arr: [1, 2] });
+  });
+});

--- a/packages/mcp-core/src/tools/components-v2/_lib/interpolate.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/interpolate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { interpolateTemplate } from './interpolate.js';
 
 describe('interpolateTemplate', () => {

--- a/packages/mcp-core/src/tools/components-v2/_lib/interpolate.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/interpolate.ts
@@ -1,0 +1,18 @@
+const TEMPLATE_RE = /\{\{(\w+)\}\}/g;
+
+export function interpolateTemplate<T>(value: T, vars: Record<string, string>): T {
+  if (typeof value === 'string') {
+    return value.replace(TEMPLATE_RE, (_, key: string) => vars[key] ?? `{{${key}}}`) as never as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => interpolateTemplate(v, vars)) as never as T;
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = interpolateTemplate(v, vars);
+    }
+    return out as T;
+  }
+  return value;
+}

--- a/packages/mcp-core/src/tools/components-v2/_lib/preview.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/preview.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { renderPreview } from './preview.js';
 
 describe('renderPreview', () => {
@@ -51,10 +51,7 @@ describe('renderPreview', () => {
     const out = renderPreview([
       {
         type: 12,
-        items: [
-          { media: { url: 'https://x/a.png' } },
-          { media: { url: 'https://x/b.png' } },
-        ],
+        items: [{ media: { url: 'https://x/a.png' } }, { media: { url: 'https://x/b.png' } }],
       },
     ]);
     expect(out).toContain('MediaGallery');

--- a/packages/mcp-core/src/tools/components-v2/_lib/preview.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/preview.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { renderPreview } from './preview.js';
+
+describe('renderPreview', () => {
+  it('renders a TextDisplay as plain text', () => {
+    const out = renderPreview([{ type: 10, content: 'hello world' }]);
+    expect(out).toContain('hello world');
+  });
+
+  it('renders a Container with accent_color note', () => {
+    const out = renderPreview([
+      {
+        type: 17,
+        accent_color: 5793266,
+        components: [{ type: 10, content: 'Title' }],
+      },
+    ]);
+    expect(out).toContain('Container');
+    expect(out).toContain('#5865F2');
+    expect(out).toContain('Title');
+  });
+
+  it('renders a Section with Thumbnail accessory marker', () => {
+    const out = renderPreview([
+      {
+        type: 9,
+        components: [{ type: 10, content: 'Header' }],
+        accessory: { type: 11, media: { url: 'https://x/y.png' } },
+      },
+    ]);
+    expect(out).toContain('Section');
+    expect(out).toContain('Header');
+    expect(out).toMatch(/Thumb/i);
+  });
+
+  it('renders an ActionRow with Button labels', () => {
+    const out = renderPreview([
+      {
+        type: 1,
+        components: [
+          { type: 2, style: 1, label: 'Yes', custom_id: 'y' },
+          { type: 2, style: 4, label: 'No', custom_id: 'n' },
+        ],
+      },
+    ]);
+    expect(out).toContain('[ Yes ]');
+    expect(out).toContain('[ No ]');
+  });
+
+  it('renders a MediaGallery with item count', () => {
+    const out = renderPreview([
+      {
+        type: 12,
+        items: [
+          { media: { url: 'https://x/a.png' } },
+          { media: { url: 'https://x/b.png' } },
+        ],
+      },
+    ]);
+    expect(out).toContain('MediaGallery');
+    expect(out).toContain('2 items');
+  });
+
+  it('renders a Separator', () => {
+    const out = renderPreview([{ type: 14, divider: true }]);
+    expect(out).toMatch(/Separator|─{3,}/);
+  });
+});

--- a/packages/mcp-core/src/tools/components-v2/_lib/preview.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/preview.ts
@@ -1,0 +1,82 @@
+import { ComponentTypeId } from './schema.js';
+
+interface Node {
+  type?: number;
+  content?: string;
+  components?: Node[];
+  accessory?: Node;
+  items?: unknown[];
+  media?: { url?: string };
+  accent_color?: number;
+  style?: number;
+  label?: string;
+  custom_id?: string;
+  url?: string;
+  divider?: boolean;
+  spacing?: number;
+}
+
+function renderNode(n: Node, indent: number): string[] {
+  const pad = '  '.repeat(indent);
+  switch (n.type) {
+    case ComponentTypeId.TextDisplay:
+      return [`${pad}${n.content ?? ''}`];
+
+    case ComponentTypeId.Button: {
+      const label = n.label ?? '(no label)';
+      const id = n.url !== undefined ? `[link ${n.url}]` : `[id:${n.custom_id ?? '?'}]`;
+      return [`${pad}[ ${label} ] ${id}`];
+    }
+
+    case ComponentTypeId.Thumbnail:
+      return [`${pad}[Thumb ${n.media?.url ?? '?'}]`];
+
+    case ComponentTypeId.Separator:
+      return [`${pad}${n.divider !== false ? '─'.repeat(40) : '·'.repeat(40)}  (Separator${n.spacing === 2 ? ', large' : ''})`];
+
+    case ComponentTypeId.MediaGallery:
+      return [`${pad}MediaGallery (${(n.items ?? []).length} items)`];
+
+    case ComponentTypeId.File:
+      return [`${pad}File ${(n as { file?: { url?: string } }).file?.url ?? '?'}`];
+
+    case ComponentTypeId.Section: {
+      const lines: string[] = [`${pad}Section`];
+      for (const c of n.components ?? []) lines.push(...renderNode(c, indent + 1));
+      if (n.accessory !== undefined) {
+        lines.push(`${pad}  → accessory:`);
+        lines.push(...renderNode(n.accessory, indent + 2));
+      }
+      return lines;
+    }
+
+    case ComponentTypeId.ActionRow: {
+      const buttons = (n.components ?? []).map((c) => renderNode(c, 0).join(' ').trim());
+      return [`${pad}ActionRow: ${buttons.join('  ')}`];
+    }
+
+    case ComponentTypeId.Container: {
+      const accentHex =
+        n.accent_color !== undefined ? `#${n.accent_color.toString(16).padStart(6, '0').toUpperCase()}` : '';
+      const lines: string[] = [`${pad}Container ${accentHex}`.trimEnd()];
+      for (const c of n.components ?? []) lines.push(...renderNode(c, indent + 1));
+      return lines;
+    }
+
+    case ComponentTypeId.StringSelect:
+    case ComponentTypeId.UserSelect:
+    case ComponentTypeId.RoleSelect:
+    case ComponentTypeId.MentionableSelect:
+    case ComponentTypeId.ChannelSelect:
+      return [`${pad}Select (type ${n.type ?? '?'}, custom_id:${(n as { custom_id?: string }).custom_id ?? '?'})`];
+
+    default:
+      return [`${pad}<unknown type ${n.type ?? '?'}>`];
+  }
+}
+
+export function renderPreview(components: readonly Node[]): string {
+  const lines: string[] = [];
+  for (const c of components) lines.push(...renderNode(c, 0));
+  return lines.join('\n');
+}

--- a/packages/mcp-core/src/tools/components-v2/_lib/preview.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/preview.ts
@@ -32,7 +32,9 @@ function renderNode(n: Node, indent: number): string[] {
       return [`${pad}[Thumb ${n.media?.url ?? '?'}]`];
 
     case ComponentTypeId.Separator:
-      return [`${pad}${n.divider !== false ? '─'.repeat(40) : '·'.repeat(40)}  (Separator${n.spacing === 2 ? ', large' : ''})`];
+      return [
+        `${pad}${n.divider !== false ? '─'.repeat(40) : '·'.repeat(40)}  (Separator${n.spacing === 2 ? ', large' : ''})`,
+      ];
 
     case ComponentTypeId.MediaGallery:
       return [`${pad}MediaGallery (${(n.items ?? []).length} items)`];
@@ -57,7 +59,9 @@ function renderNode(n: Node, indent: number): string[] {
 
     case ComponentTypeId.Container: {
       const accentHex =
-        n.accent_color !== undefined ? `#${n.accent_color.toString(16).padStart(6, '0').toUpperCase()}` : '';
+        n.accent_color !== undefined
+          ? `#${n.accent_color.toString(16).padStart(6, '0').toUpperCase()}`
+          : '';
       const lines: string[] = [`${pad}Container ${accentHex}`.trimEnd()];
       for (const c of n.components ?? []) lines.push(...renderNode(c, indent + 1));
       return lines;
@@ -68,7 +72,9 @@ function renderNode(n: Node, indent: number): string[] {
     case ComponentTypeId.RoleSelect:
     case ComponentTypeId.MentionableSelect:
     case ComponentTypeId.ChannelSelect:
-      return [`${pad}Select (type ${n.type ?? '?'}, custom_id:${(n as { custom_id?: string }).custom_id ?? '?'})`];
+      return [
+        `${pad}Select (type ${n.type ?? '?'}, custom_id:${(n as { custom_id?: string }).custom_id ?? '?'})`,
+      ];
 
     default:
       return [`${pad}<unknown type ${n.type ?? '?'}>`];

--- a/packages/mcp-core/src/tools/components-v2/_lib/schema.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/schema.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { ComponentV2, ComponentsV2Array, ComponentTypeId } from './schema.js';
+
+describe('ComponentV2 discriminated union', () => {
+  it('parses a TextDisplay (type 10)', () => {
+    const r = ComponentV2.safeParse({ type: 10, content: 'hello world' });
+    expect(r.success).toBe(true);
+  });
+
+  it('parses a Button (type 2) with label + custom_id', () => {
+    const r = ComponentV2.safeParse({ type: 2, style: 1, label: 'Click', custom_id: 'click_me' });
+    expect(r.success).toBe(true);
+  });
+
+  it('parses a link Button (style 5) with url instead of custom_id', () => {
+    const r = ComponentV2.safeParse({ type: 2, style: 5, label: 'Open', url: 'https://example.com' });
+    expect(r.success).toBe(true);
+  });
+
+  it('parses a Container (type 17) with nested Section + Separator', () => {
+    const r = ComponentV2.safeParse({
+      type: 17,
+      accent_color: 5793266,
+      components: [
+        {
+          type: 9,
+          components: [{ type: 10, content: 'Section title' }],
+          accessory: { type: 11, media: { url: 'https://example.com/img.png' } },
+        },
+        { type: 14, divider: true, spacing: 2 },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('parses a MediaGallery (type 12) with items', () => {
+    const r = ComponentV2.safeParse({
+      type: 12,
+      items: [
+        { media: { url: 'https://example.com/a.png' } },
+        { media: { url: 'https://example.com/b.png' }, description: 'cap', spoiler: true },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects unknown type id', () => {
+    const r = ComponentV2.safeParse({ type: 99, content: 'oops' });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects TextDisplay over 4000 chars', () => {
+    const r = ComponentV2.safeParse({ type: 10, content: 'x'.repeat(4001) });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects Button without custom_id AND without url', () => {
+    const r = ComponentV2.safeParse({ type: 2, style: 1, label: 'no-id-no-url' });
+    expect(r.success).toBe(false);
+  });
+
+  it('ComponentsV2Array accepts 1-40 items', () => {
+    expect(ComponentsV2Array.safeParse([{ type: 10, content: 'one' }]).success).toBe(true);
+    expect(ComponentsV2Array.safeParse([]).success).toBe(false);
+    const huge = Array.from({ length: 41 }, () => ({ type: 10 as const, content: 'x' }));
+    expect(ComponentsV2Array.safeParse(huge).success).toBe(false);
+  });
+
+  it('ComponentTypeId enum-like helper exposes the 9 V2-specific ids', () => {
+    expect(ComponentTypeId.ActionRow).toBe(1);
+    expect(ComponentTypeId.Button).toBe(2);
+    expect(ComponentTypeId.Section).toBe(9);
+    expect(ComponentTypeId.TextDisplay).toBe(10);
+    expect(ComponentTypeId.Thumbnail).toBe(11);
+    expect(ComponentTypeId.MediaGallery).toBe(12);
+    expect(ComponentTypeId.File).toBe(13);
+    expect(ComponentTypeId.Separator).toBe(14);
+    expect(ComponentTypeId.Container).toBe(17);
+  });
+});

--- a/packages/mcp-core/src/tools/components-v2/_lib/schema.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/schema.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { ComponentV2, ComponentsV2Array, ComponentTypeId } from './schema.js';
+import { describe, expect, it } from 'vitest';
+import { ComponentsV2Array, ComponentTypeId, ComponentV2 } from './schema.js';
 
 describe('ComponentV2 discriminated union', () => {
   it('parses a TextDisplay (type 10)', () => {
@@ -13,7 +13,12 @@ describe('ComponentV2 discriminated union', () => {
   });
 
   it('parses a link Button (style 5) with url instead of custom_id', () => {
-    const r = ComponentV2.safeParse({ type: 2, style: 5, label: 'Open', url: 'https://example.com' });
+    const r = ComponentV2.safeParse({
+      type: 2,
+      style: 5,
+      label: 'Open',
+      url: 'https://example.com',
+    });
     expect(r.success).toBe(true);
   });
 

--- a/packages/mcp-core/src/tools/components-v2/_lib/schema.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/schema.ts
@@ -103,17 +103,29 @@ const Separator = z.object({
   spacing: z.number().int().min(1).max(2).optional(),
 });
 
-const Select = z.discriminatedUnion('type', [StringSelect, UserSelect, RoleSelect, MentionableSelect, ChannelSelect]);
+const Select = z.discriminatedUnion('type', [
+  StringSelect,
+  UserSelect,
+  RoleSelect,
+  MentionableSelect,
+  ChannelSelect,
+]);
 
 const ActionRow = z.object({
   type: z.literal(1),
-  components: z.array(z.union([Button, Select])).min(1).max(5),
+  components: z
+    .array(z.union([Button, Select]))
+    .min(1)
+    .max(5),
 });
 
 const Container: z.ZodType<unknown> = z.lazy(() =>
   z.object({
     type: z.literal(17),
-    components: z.array(z.union([Section, TextDisplay, MediaGallery, File, Separator, ActionRow])).min(1).max(10),
+    components: z
+      .array(z.union([Section, TextDisplay, MediaGallery, File, Separator, ActionRow]))
+      .min(1)
+      .max(10),
     accent_color: z.number().int().min(0).max(0xffffff).optional(),
     spoiler: z.boolean().optional(),
   }),

--- a/packages/mcp-core/src/tools/components-v2/_lib/schema.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/schema.ts
@@ -1,0 +1,141 @@
+import { z } from 'zod';
+
+export const ComponentTypeId = {
+  ActionRow: 1,
+  Button: 2,
+  StringSelect: 3,
+  TextInput: 4,
+  UserSelect: 5,
+  RoleSelect: 6,
+  MentionableSelect: 7,
+  ChannelSelect: 8,
+  Section: 9,
+  TextDisplay: 10,
+  Thumbnail: 11,
+  MediaGallery: 12,
+  File: 13,
+  Separator: 14,
+  Container: 17,
+} as const;
+
+const Emoji = z.object({
+  id: z.string().optional(),
+  name: z.string(),
+  animated: z.boolean().optional(),
+});
+
+const ButtonBase = z.object({
+  type: z.literal(2),
+  style: z.number().int().min(1).max(6),
+  label: z.string().max(80).optional(),
+  emoji: Emoji.optional(),
+  disabled: z.boolean().optional(),
+});
+const Button = z.union([
+  ButtonBase.extend({ custom_id: z.string().min(1).max(100), url: z.never().optional() }),
+  ButtonBase.extend({ url: z.string().url(), custom_id: z.never().optional() }),
+]);
+
+const SelectOption = z.object({
+  label: z.string().max(100),
+  value: z.string().max(100),
+  description: z.string().max(100).optional(),
+  emoji: Emoji.optional(),
+  default: z.boolean().optional(),
+});
+
+const SelectBase = z.object({
+  custom_id: z.string().min(1).max(100),
+  placeholder: z.string().max(150).optional(),
+  min_values: z.number().int().min(0).max(25).default(1),
+  max_values: z.number().int().min(1).max(25).default(1),
+  disabled: z.boolean().optional(),
+});
+const StringSelect = SelectBase.extend({
+  type: z.literal(3),
+  options: z.array(SelectOption).min(1).max(25),
+});
+const UserSelect = SelectBase.extend({ type: z.literal(5) });
+const RoleSelect = SelectBase.extend({ type: z.literal(6) });
+const MentionableSelect = SelectBase.extend({ type: z.literal(7) });
+const ChannelSelect = SelectBase.extend({
+  type: z.literal(8),
+  channel_types: z.array(z.number().int()).optional(),
+});
+
+const TextDisplay = z.object({
+  type: z.literal(10),
+  content: z.string().min(1).max(4000),
+});
+
+const Thumbnail = z.object({
+  type: z.literal(11),
+  media: z.object({ url: z.string().url() }),
+  description: z.string().max(1024).optional(),
+  spoiler: z.boolean().optional(),
+});
+
+const Section = z.object({
+  type: z.literal(9),
+  components: z.array(TextDisplay).min(1).max(3),
+  accessory: z.union([Thumbnail, Button]).optional(),
+});
+
+const MediaGalleryItem = z.object({
+  media: z.object({ url: z.string().url() }),
+  description: z.string().max(1024).optional(),
+  spoiler: z.boolean().optional(),
+});
+const MediaGallery = z.object({
+  type: z.literal(12),
+  items: z.array(MediaGalleryItem).min(1).max(10),
+});
+
+const File = z.object({
+  type: z.literal(13),
+  file: z.object({ url: z.string() }),
+  spoiler: z.boolean().optional(),
+});
+
+const Separator = z.object({
+  type: z.literal(14),
+  divider: z.boolean().optional(),
+  spacing: z.number().int().min(1).max(2).optional(),
+});
+
+const Select = z.discriminatedUnion('type', [StringSelect, UserSelect, RoleSelect, MentionableSelect, ChannelSelect]);
+
+const ActionRow = z.object({
+  type: z.literal(1),
+  components: z.array(z.union([Button, Select])).min(1).max(5),
+});
+
+const Container: z.ZodType<unknown> = z.lazy(() =>
+  z.object({
+    type: z.literal(17),
+    components: z.array(z.union([Section, TextDisplay, MediaGallery, File, Separator, ActionRow])).min(1).max(10),
+    accent_color: z.number().int().min(0).max(0xffffff).optional(),
+    spoiler: z.boolean().optional(),
+  }),
+);
+
+export const ComponentV2 = z.union([
+  ActionRow,
+  Button,
+  StringSelect,
+  UserSelect,
+  RoleSelect,
+  MentionableSelect,
+  ChannelSelect,
+  Section,
+  TextDisplay,
+  Thumbnail,
+  MediaGallery,
+  File,
+  Separator,
+  Container as z.ZodType<{ type: 17 } & Record<string, unknown>>,
+]);
+
+export const ComponentsV2Array = z.array(ComponentV2).min(1).max(40);
+
+export type ComponentV2Input = z.infer<typeof ComponentV2>;

--- a/packages/mcp-core/src/tools/components-v2/_lib/validator.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/validator.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { validateComponentsV2 } from './validator.js';
+
+describe('validateComponentsV2', () => {
+  it('accepts a minimal valid Container with Section', () => {
+    const r = validateComponentsV2([
+      {
+        type: 17,
+        components: [
+          { type: 9, components: [{ type: 10, content: 'hi' }] },
+        ],
+      },
+    ]);
+    expect(r.valid).toBe(true);
+    expect(r.issues).toEqual([]);
+  });
+
+  it('rejects Container nested inside Container', () => {
+    const r = validateComponentsV2([
+      {
+        type: 17,
+        components: [
+          { type: 17, components: [{ type: 10, content: 'inner' }] },
+        ],
+      },
+    ]);
+    expect(r.valid).toBe(false);
+    expect(r.issues.some((i) => i.code === 'CONTAINER_IN_CONTAINER')).toBe(true);
+  });
+
+  it('rejects Section accessory that is neither Thumbnail nor Button', () => {
+    const r = validateComponentsV2([
+      {
+        type: 9,
+        components: [{ type: 10, content: 'x' }],
+        accessory: { type: 14 } as never,
+      },
+    ]);
+    expect(r.valid).toBe(false);
+    expect(r.issues.some((i) => i.code === 'INVALID_ACCESSORY')).toBe(true);
+  });
+
+  it('rejects total components > 40 (recursive count)', () => {
+    const items = Array.from({ length: 41 }, () => ({ type: 10 as const, content: 'x' }));
+    const r = validateComponentsV2(items);
+    expect(r.valid).toBe(false);
+    expect(r.issues.some((i) => i.code === 'OVER_40')).toBe(true);
+  });
+
+  it('rejects Container with > 10 children', () => {
+    const r = validateComponentsV2([
+      {
+        type: 17,
+        components: Array.from({ length: 11 }, () => ({ type: 10 as const, content: 'x' })),
+      },
+    ]);
+    expect(r.valid).toBe(false);
+    expect(r.issues.some((i) => i.code === 'CONTAINER_OVER_10')).toBe(true);
+  });
+
+  it('rejects MediaGallery with 0 items', () => {
+    expect(
+      validateComponentsV2([{ type: 12, items: [] as never[] }]).issues.some((i) => i.code === 'GALLERY_RANGE'),
+    ).toBe(true);
+  });
+
+  it('rejects ActionRow with > 5 components', () => {
+    const r = validateComponentsV2([
+      {
+        type: 1,
+        components: Array.from({ length: 6 }, (_, i) => ({ type: 2 as const, style: 1, label: 'b', custom_id: `b${i}` })),
+      },
+    ]);
+    expect(r.valid).toBe(false);
+    expect(r.issues.some((i) => i.code === 'ACTIONROW_OVER_5')).toBe(true);
+  });
+
+  it('rejects standalone Thumbnail', () => {
+    const r = validateComponentsV2([{ type: 11, media: { url: 'https://x/y.png' } }] as never);
+    expect(r.valid).toBe(false);
+    expect(r.issues.some((i) => i.code === 'THUMBNAIL_STANDALONE')).toBe(true);
+  });
+
+  it('rejects Button missing both custom_id and url', () => {
+    const r = validateComponentsV2([
+      { type: 1, components: [{ type: 2, style: 1, label: 'broken' } as never] },
+    ]);
+    expect(r.valid).toBe(false);
+    expect(r.issues.some((i) => i.code === 'BUTTON_NO_ID_OR_URL')).toBe(true);
+  });
+
+  it('issues carry path and fix_hint', () => {
+    const r = validateComponentsV2([
+      { type: 17, components: Array.from({ length: 11 }, () => ({ type: 10 as const, content: 'x' })) },
+    ]);
+    const overflow = r.issues.find((i) => i.code === 'CONTAINER_OVER_10');
+    expect(overflow?.path).toBe('components[0]');
+    expect(overflow?.fix_hint).toMatch(/split|reduce/i);
+  });
+});

--- a/packages/mcp-core/src/tools/components-v2/_lib/validator.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/validator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { validateComponentsV2 } from './validator.js';
 
 describe('validateComponentsV2', () => {
@@ -6,9 +6,7 @@ describe('validateComponentsV2', () => {
     const r = validateComponentsV2([
       {
         type: 17,
-        components: [
-          { type: 9, components: [{ type: 10, content: 'hi' }] },
-        ],
+        components: [{ type: 9, components: [{ type: 10, content: 'hi' }] }],
       },
     ]);
     expect(r.valid).toBe(true);
@@ -19,9 +17,7 @@ describe('validateComponentsV2', () => {
     const r = validateComponentsV2([
       {
         type: 17,
-        components: [
-          { type: 17, components: [{ type: 10, content: 'inner' }] },
-        ],
+        components: [{ type: 17, components: [{ type: 10, content: 'inner' }] }],
       },
     ]);
     expect(r.valid).toBe(false);
@@ -60,7 +56,9 @@ describe('validateComponentsV2', () => {
 
   it('rejects MediaGallery with 0 items', () => {
     expect(
-      validateComponentsV2([{ type: 12, items: [] as never[] }]).issues.some((i) => i.code === 'GALLERY_RANGE'),
+      validateComponentsV2([{ type: 12, items: [] as never[] }]).issues.some(
+        (i) => i.code === 'GALLERY_RANGE',
+      ),
     ).toBe(true);
   });
 
@@ -68,7 +66,12 @@ describe('validateComponentsV2', () => {
     const r = validateComponentsV2([
       {
         type: 1,
-        components: Array.from({ length: 6 }, (_, i) => ({ type: 2 as const, style: 1, label: 'b', custom_id: `b${i}` })),
+        components: Array.from({ length: 6 }, (_, i) => ({
+          type: 2 as const,
+          style: 1,
+          label: 'b',
+          custom_id: `b${i}`,
+        })),
       },
     ]);
     expect(r.valid).toBe(false);
@@ -91,7 +94,10 @@ describe('validateComponentsV2', () => {
 
   it('issues carry path and fix_hint', () => {
     const r = validateComponentsV2([
-      { type: 17, components: Array.from({ length: 11 }, () => ({ type: 10 as const, content: 'x' })) },
+      {
+        type: 17,
+        components: Array.from({ length: 11 }, () => ({ type: 10 as const, content: 'x' })),
+      },
     ]);
     const overflow = r.issues.find((i) => i.code === 'CONTAINER_OVER_10');
     expect(overflow?.path).toBe('components[0]');

--- a/packages/mcp-core/src/tools/components-v2/_lib/validator.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/validator.ts
@@ -1,0 +1,145 @@
+import { ComponentTypeId } from './schema.js';
+
+export interface ValidatorIssue {
+  readonly path: string;
+  readonly code: string;
+  readonly message: string;
+  readonly fix_hint?: string;
+}
+
+export interface ValidatorResult {
+  readonly valid: boolean;
+  readonly issues: readonly ValidatorIssue[];
+}
+
+interface Node {
+  type?: number;
+  components?: Node[];
+  items?: unknown[];
+  accessory?: { type?: number };
+  custom_id?: string;
+  url?: string;
+  style?: number;
+  content?: string;
+  file?: { url?: string };
+  media?: { url?: string };
+}
+
+function countRecursive(nodes: readonly Node[]): number {
+  let count = 0;
+  for (const n of nodes) {
+    count += 1;
+    if (Array.isArray(n.components)) count += countRecursive(n.components);
+    if (n.type === ComponentTypeId.Section && n.accessory !== undefined) count += 1;
+  }
+  return count;
+}
+
+function toNodes(input: unknown): Node[] {
+  if (!Array.isArray(input)) return [];
+  return input as Node[];
+}
+
+export function validateComponentsV2(input: unknown): ValidatorResult {
+  const issues: ValidatorIssue[] = [];
+  const components = toNodes(input);
+
+  const total = countRecursive(components);
+  if (total > 40) {
+    issues.push({
+      path: 'components',
+      code: 'OVER_40',
+      message: `Total components ${total} exceeds 40-cap.`,
+      fix_hint: 'Split content across multiple messages or move items into a Container with fewer children.',
+    });
+  }
+
+  const walk = (nodes: readonly Node[], path: string, parentType: number | null): void => {
+    nodes.forEach((node, idx) => {
+      const here = `${path}[${idx}]`;
+
+      if (node.type === ComponentTypeId.Container && parentType === ComponentTypeId.Container) {
+        issues.push({
+          path: here,
+          code: 'CONTAINER_IN_CONTAINER',
+          message: 'Container cannot be nested inside another Container.',
+          fix_hint: 'Move the inner components up one level or use a Section instead.',
+        });
+      }
+
+      if (node.type === ComponentTypeId.Container && Array.isArray(node.components) && node.components.length > 10) {
+        issues.push({
+          path: here,
+          code: 'CONTAINER_OVER_10',
+          message: `Container has ${node.components.length} children; cap is 10.`,
+          fix_hint: 'Split into multiple Containers or reduce TextDisplay count.',
+        });
+      }
+
+      if (node.type === ComponentTypeId.ActionRow && Array.isArray(node.components) && node.components.length > 5) {
+        issues.push({
+          path: here,
+          code: 'ACTIONROW_OVER_5',
+          message: `ActionRow has ${node.components.length} components; cap is 5.`,
+        });
+      }
+
+      if (node.type === ComponentTypeId.Thumbnail && parentType !== ComponentTypeId.Section) {
+        issues.push({
+          path: here,
+          code: 'THUMBNAIL_STANDALONE',
+          message: 'Thumbnail is only valid as a Section.accessory.',
+        });
+      }
+
+      if (node.type === ComponentTypeId.Section && node.accessory !== undefined) {
+        const at = node.accessory.type;
+        if (at !== ComponentTypeId.Thumbnail && at !== ComponentTypeId.Button) {
+          issues.push({
+            path: `${here}.accessory`,
+            code: 'INVALID_ACCESSORY',
+            message: `Section accessory must be Thumbnail (11) or Button (2); got type ${at}.`,
+          });
+        }
+      }
+
+      if (node.type === ComponentTypeId.MediaGallery) {
+        const itemCount = Array.isArray(node.items) ? node.items.length : 0;
+        if (itemCount < 1 || itemCount > 10) {
+          issues.push({
+            path: `${here}.items`,
+            code: 'GALLERY_RANGE',
+            message: `MediaGallery items length ${itemCount} outside 1-10.`,
+          });
+        }
+      }
+
+      if (node.type === ComponentTypeId.Button && node.custom_id === undefined && node.url === undefined) {
+        issues.push({
+          path: here,
+          code: 'BUTTON_NO_ID_OR_URL',
+          message: 'Button needs either custom_id (action) or url (link, style 5).',
+        });
+      }
+
+      if (Array.isArray(node.components)) {
+        walk(node.components, `${here}.components`, node.type ?? null);
+      }
+
+      // Walk ActionRow children for Button checks
+      if (node.type === ComponentTypeId.ActionRow && Array.isArray(node.components)) {
+        node.components.forEach((child, cidx) => {
+          const childHere = `${here}.components[${cidx}]`;
+          if (child.type === ComponentTypeId.Button && child.custom_id === undefined && child.url === undefined) {
+            // already walked above via the components walk
+          }
+          void childHere;
+        });
+      }
+    });
+  };
+
+  walk(components, 'components', null);
+
+  return { valid: issues.length === 0, issues };
+}

--- a/packages/mcp-core/src/tools/components-v2/_lib/validator.ts
+++ b/packages/mcp-core/src/tools/components-v2/_lib/validator.ts
@@ -50,7 +50,8 @@ export function validateComponentsV2(input: unknown): ValidatorResult {
       path: 'components',
       code: 'OVER_40',
       message: `Total components ${total} exceeds 40-cap.`,
-      fix_hint: 'Split content across multiple messages or move items into a Container with fewer children.',
+      fix_hint:
+        'Split content across multiple messages or move items into a Container with fewer children.',
     });
   }
 
@@ -67,7 +68,11 @@ export function validateComponentsV2(input: unknown): ValidatorResult {
         });
       }
 
-      if (node.type === ComponentTypeId.Container && Array.isArray(node.components) && node.components.length > 10) {
+      if (
+        node.type === ComponentTypeId.Container &&
+        Array.isArray(node.components) &&
+        node.components.length > 10
+      ) {
         issues.push({
           path: here,
           code: 'CONTAINER_OVER_10',
@@ -76,7 +81,11 @@ export function validateComponentsV2(input: unknown): ValidatorResult {
         });
       }
 
-      if (node.type === ComponentTypeId.ActionRow && Array.isArray(node.components) && node.components.length > 5) {
+      if (
+        node.type === ComponentTypeId.ActionRow &&
+        Array.isArray(node.components) &&
+        node.components.length > 5
+      ) {
         issues.push({
           path: here,
           code: 'ACTIONROW_OVER_5',
@@ -114,7 +123,11 @@ export function validateComponentsV2(input: unknown): ValidatorResult {
         }
       }
 
-      if (node.type === ComponentTypeId.Button && node.custom_id === undefined && node.url === undefined) {
+      if (
+        node.type === ComponentTypeId.Button &&
+        node.custom_id === undefined &&
+        node.url === undefined
+      ) {
         issues.push({
           path: here,
           code: 'BUTTON_NO_ID_OR_URL',
@@ -130,7 +143,11 @@ export function validateComponentsV2(input: unknown): ValidatorResult {
       if (node.type === ComponentTypeId.ActionRow && Array.isArray(node.components)) {
         node.components.forEach((child, cidx) => {
           const childHere = `${here}.components[${cidx}]`;
-          if (child.type === ComponentTypeId.Button && child.custom_id === undefined && child.url === undefined) {
+          if (
+            child.type === ComponentTypeId.Button &&
+            child.custom_id === undefined &&
+            child.url === undefined
+          ) {
             // already walked above via the components walk
           }
           void childHere;

--- a/packages/mcp-core/src/tools/components-v2/build_container.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/build_container.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import buildContainer from './build_container.js';
+
+describe('components_v2_build_container', () => {
+  it('returns a valid Container JSON node', async () => {
+    const T = buildContainer;
+    const t = new T(
+      { name: 'components_v2_build_container', path: 'inline', root: 'inline', store: null as never },
+      { name: 'components_v2_build_container', enabled: true },
+    );
+    const r = (await t.run(
+      {
+        components: [{ type: 10, content: 'hi' }],
+        accent_color: 5793266,
+      },
+      { signal: new AbortController().signal },
+    )) as { isError: boolean; structuredContent: { component: { type: number; accent_color?: number } } };
+    expect(r.isError).toBe(false);
+    expect(r.structuredContent.component.type).toBe(17);
+    expect(r.structuredContent.component.accent_color).toBe(5793266);
+  });
+
+  it('omits accent_color when not provided', async () => {
+    const T = buildContainer;
+    const t = new T(
+      { name: 'components_v2_build_container', path: 'inline', root: 'inline', store: null as never },
+      { name: 'components_v2_build_container', enabled: true },
+    );
+    const r = (await t.run(
+      { components: [{ type: 10, content: 'hi' }] },
+      { signal: new AbortController().signal },
+    )) as { isError: boolean; structuredContent: { component: Record<string, unknown> } };
+    expect(r.structuredContent.component['accent_color']).toBeUndefined();
+  });
+});

--- a/packages/mcp-core/src/tools/components-v2/build_container.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/build_container.test.ts
@@ -1,11 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import buildContainer from './build_container.js';
 
 describe('components_v2_build_container', () => {
   it('returns a valid Container JSON node', async () => {
     const T = buildContainer;
     const t = new T(
-      { name: 'components_v2_build_container', path: 'inline', root: 'inline', store: null as never },
+      {
+        name: 'components_v2_build_container',
+        path: 'inline',
+        root: 'inline',
+        store: null as never,
+      },
       { name: 'components_v2_build_container', enabled: true },
     );
     const r = (await t.run(
@@ -14,7 +19,10 @@ describe('components_v2_build_container', () => {
         accent_color: 5793266,
       },
       { signal: new AbortController().signal },
-    )) as { isError: boolean; structuredContent: { component: { type: number; accent_color?: number } } };
+    )) as {
+      isError: boolean;
+      structuredContent: { component: { type: number; accent_color?: number } };
+    };
     expect(r.isError).toBe(false);
     expect(r.structuredContent.component.type).toBe(17);
     expect(r.structuredContent.component.accent_color).toBe(5793266);
@@ -23,7 +31,12 @@ describe('components_v2_build_container', () => {
   it('omits accent_color when not provided', async () => {
     const T = buildContainer;
     const t = new T(
-      { name: 'components_v2_build_container', path: 'inline', root: 'inline', store: null as never },
+      {
+        name: 'components_v2_build_container',
+        path: 'inline',
+        root: 'inline',
+        store: null as never,
+      },
       { name: 'components_v2_build_container', enabled: true },
     );
     const r = (await t.run(

--- a/packages/mcp-core/src/tools/components-v2/build_container.ts
+++ b/packages/mcp-core/src/tools/components-v2/build_container.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { defineTool } from '../_lib/defineTool.js';
+import { dualResult } from '../_lib/response.js';
+
+export default defineTool({
+  name: 'components_v2_build_container',
+  category: 'components_v2',
+  description:
+    '**Purpose**: Build a Components V2 Container (type 17) JSON node ready to nest into `components_v2_send`.\n\n**When to use**: compose a card with accent color + multiple sections/separators.\n\n**Returns**: `{component}` — the JSON node. Pass it inside the `components` array of `components_v2_send`.',
+  inputSchema: {
+    components: z
+      .array(z.unknown())
+      .min(1)
+      .max(10)
+      .describe(
+        'Up to 10 child nodes (Section/TextDisplay/MediaGallery/File/Separator/ActionRow). NOT another Container.',
+      ),
+    accent_color: z
+      .number()
+      .int()
+      .min(0)
+      .max(0xffffff)
+      .optional()
+      .describe('Hex RGB integer (0xFF0000 = red)'),
+    spoiler: z.boolean().optional().describe('Wrap container in spoiler tag'),
+  },
+  outputSchema: {
+    component: z.unknown(),
+  },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  idempotent: true,
+  handler: async (args) => {
+    const component: Record<string, unknown> = {
+      type: 17,
+      components: args.components,
+    };
+    if (args.accent_color !== undefined) component['accent_color'] = args.accent_color;
+    if (args.spoiler !== undefined) component['spoiler'] = args.spoiler;
+    return dualResult({ text: 'Built Container.', data: { component } });
+  },
+});

--- a/packages/mcp-core/src/tools/components-v2/build_media_gallery.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/build_media_gallery.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import buildMediaGallery from './build_media_gallery.js';
+
+describe('components_v2_build_media_gallery', () => {
+  it('builds MediaGallery from items', async () => {
+    const T = buildMediaGallery;
+    const t = new T(
+      { name: 'components_v2_build_media_gallery', path: 'inline', root: 'inline', store: null as never },
+      { name: 'components_v2_build_media_gallery', enabled: true },
+    );
+    const r = (await t.run(
+      {
+        items: [
+          { url: 'https://example.com/a.png' },
+          { url: 'https://example.com/b.png', description: 'caption', spoiler: true },
+        ],
+      },
+      { signal: new AbortController().signal },
+    )) as { isError: boolean; structuredContent: { component: { type: number; items: Array<{ media: { url: string }; description?: string; spoiler?: boolean }> } } };
+    expect(r.isError).toBe(false);
+    expect(r.structuredContent.component.type).toBe(12);
+    expect(r.structuredContent.component.items).toHaveLength(2);
+    expect(r.structuredContent.component.items[0]!.media.url).toBe('https://example.com/a.png');
+    expect(r.structuredContent.component.items[1]!.description).toBe('caption');
+    expect(r.structuredContent.component.items[1]!.spoiler).toBe(true);
+  });
+});

--- a/packages/mcp-core/src/tools/components-v2/build_media_gallery.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/build_media_gallery.test.ts
@@ -1,11 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import buildMediaGallery from './build_media_gallery.js';
 
 describe('components_v2_build_media_gallery', () => {
   it('builds MediaGallery from items', async () => {
     const T = buildMediaGallery;
     const t = new T(
-      { name: 'components_v2_build_media_gallery', path: 'inline', root: 'inline', store: null as never },
+      {
+        name: 'components_v2_build_media_gallery',
+        path: 'inline',
+        root: 'inline',
+        store: null as never,
+      },
       { name: 'components_v2_build_media_gallery', enabled: true },
     );
     const r = (await t.run(
@@ -16,7 +21,15 @@ describe('components_v2_build_media_gallery', () => {
         ],
       },
       { signal: new AbortController().signal },
-    )) as { isError: boolean; structuredContent: { component: { type: number; items: Array<{ media: { url: string }; description?: string; spoiler?: boolean }> } } };
+    )) as {
+      isError: boolean;
+      structuredContent: {
+        component: {
+          type: number;
+          items: Array<{ media: { url: string }; description?: string; spoiler?: boolean }>;
+        };
+      };
+    };
     expect(r.isError).toBe(false);
     expect(r.structuredContent.component.type).toBe(12);
     expect(r.structuredContent.component.items).toHaveLength(2);

--- a/packages/mcp-core/src/tools/components-v2/build_media_gallery.ts
+++ b/packages/mcp-core/src/tools/components-v2/build_media_gallery.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import { defineTool } from '../_lib/defineTool.js';
+import { dualResult } from '../_lib/response.js';
+
+export default defineTool({
+  name: 'components_v2_build_media_gallery',
+  category: 'components_v2',
+  description:
+    '**Purpose**: Build a Components V2 MediaGallery (type 12) — 1-10 media items.\n\n**Returns**: `{component}` — MediaGallery JSON node.',
+  inputSchema: {
+    items: z
+      .array(
+        z.object({
+          url: z.string().url(),
+          description: z.string().max(1024).optional(),
+          spoiler: z.boolean().optional(),
+        }),
+      )
+      .min(1)
+      .max(10)
+      .describe('1-10 media items'),
+  },
+  outputSchema: { component: z.unknown() },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  idempotent: true,
+  handler: async (args) => {
+    const component = {
+      type: 12,
+      items: args.items.map((it) => {
+        const item: Record<string, unknown> = { media: { url: it.url } };
+        if (it.description !== undefined) item['description'] = it.description;
+        if (it.spoiler !== undefined) item['spoiler'] = it.spoiler;
+        return item;
+      }),
+    };
+    return dualResult({ text: 'Built MediaGallery.', data: { component } });
+  },
+});

--- a/packages/mcp-core/src/tools/components-v2/build_section.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/build_section.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import buildSection from './build_section.js';
 
 describe('components_v2_build_section', () => {
@@ -11,7 +11,12 @@ describe('components_v2_build_section', () => {
     const r = (await t.run(
       { text: ['line 1', 'line 2'] },
       { signal: new AbortController().signal },
-    )) as { isError: boolean; structuredContent: { component: { type: number; components: Array<{ type: number; content: string }> } } };
+    )) as {
+      isError: boolean;
+      structuredContent: {
+        component: { type: number; components: Array<{ type: number; content: string }> };
+      };
+    };
     expect(r.isError).toBe(false);
     expect(r.structuredContent.component.type).toBe(9);
     expect(r.structuredContent.component.components).toHaveLength(2);

--- a/packages/mcp-core/src/tools/components-v2/build_section.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/build_section.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import buildSection from './build_section.js';
+
+describe('components_v2_build_section', () => {
+  it('builds Section with TextDisplay components', async () => {
+    const T = buildSection;
+    const t = new T(
+      { name: 'components_v2_build_section', path: 'inline', root: 'inline', store: null as never },
+      { name: 'components_v2_build_section', enabled: true },
+    );
+    const r = (await t.run(
+      { text: ['line 1', 'line 2'] },
+      { signal: new AbortController().signal },
+    )) as { isError: boolean; structuredContent: { component: { type: number; components: Array<{ type: number; content: string }> } } };
+    expect(r.isError).toBe(false);
+    expect(r.structuredContent.component.type).toBe(9);
+    expect(r.structuredContent.component.components).toHaveLength(2);
+    expect(r.structuredContent.component.components[0]!.content).toBe('line 1');
+  });
+
+  it('attaches Thumbnail accessory when provided', async () => {
+    const T = buildSection;
+    const t = new T(
+      { name: 'components_v2_build_section', path: 'inline', root: 'inline', store: null as never },
+      { name: 'components_v2_build_section', enabled: true },
+    );
+    const r = (await t.run(
+      {
+        text: ['hello'],
+        accessory: { type: 11, media: { url: 'https://example.com/img.png' } },
+      },
+      { signal: new AbortController().signal },
+    )) as { isError: boolean; structuredContent: { component: { accessory?: { type: number } } } };
+    expect(r.structuredContent.component.accessory?.type).toBe(11);
+  });
+});

--- a/packages/mcp-core/src/tools/components-v2/build_section.ts
+++ b/packages/mcp-core/src/tools/components-v2/build_section.ts
@@ -8,11 +8,7 @@ export default defineTool({
   description:
     '**Purpose**: Build a Components V2 Section (type 9) — 1-3 TextDisplay lines with optional Thumbnail or Button accessory.\n\n**When to use**: card-like content with header + supporting text + image.\n\n**Returns**: `{component}` — Section JSON node.',
   inputSchema: {
-    text: z
-      .array(z.string().min(1).max(4000))
-      .min(1)
-      .max(3)
-      .describe('1-3 markdown text lines'),
+    text: z.array(z.string().min(1).max(4000)).min(1).max(3).describe('1-3 markdown text lines'),
     accessory: z
       .union([
         z.object({

--- a/packages/mcp-core/src/tools/components-v2/build_section.ts
+++ b/packages/mcp-core/src/tools/components-v2/build_section.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import { defineTool } from '../_lib/defineTool.js';
+import { dualResult } from '../_lib/response.js';
+
+export default defineTool({
+  name: 'components_v2_build_section',
+  category: 'components_v2',
+  description:
+    '**Purpose**: Build a Components V2 Section (type 9) — 1-3 TextDisplay lines with optional Thumbnail or Button accessory.\n\n**When to use**: card-like content with header + supporting text + image.\n\n**Returns**: `{component}` — Section JSON node.',
+  inputSchema: {
+    text: z
+      .array(z.string().min(1).max(4000))
+      .min(1)
+      .max(3)
+      .describe('1-3 markdown text lines'),
+    accessory: z
+      .union([
+        z.object({
+          type: z.literal(11),
+          media: z.object({ url: z.string().url() }),
+          description: z.string().max(1024).optional(),
+          spoiler: z.boolean().optional(),
+        }),
+        z.object({
+          type: z.literal(2),
+          style: z.number().int().min(1).max(6),
+          label: z.string().max(80).optional(),
+          custom_id: z.string().max(100).optional(),
+          url: z.string().url().optional(),
+          disabled: z.boolean().optional(),
+        }),
+      ])
+      .optional()
+      .describe('Optional Thumbnail (type 11) or Button (type 2)'),
+  },
+  outputSchema: {
+    component: z.unknown(),
+  },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  idempotent: true,
+  handler: async (args) => {
+    const component: Record<string, unknown> = {
+      type: 9,
+      components: args.text.map((t) => ({ type: 10, content: t })),
+    };
+    if (args.accessory !== undefined) component['accessory'] = args.accessory;
+    return dualResult({ text: 'Built Section.', data: { component } });
+  },
+});

--- a/packages/mcp-core/src/tools/components-v2/edit.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/edit.test.ts
@@ -1,14 +1,19 @@
-import { describe, it, expect } from 'vitest';
 import { REST } from '@discordjs/rest';
 import { container } from '@sapphire/pieces';
+import { describe, expect, it } from 'vitest';
 import componentsV2Edit from './edit.js';
 import '../../container.js';
 
 describe('components_v2_edit', () => {
   it('edits with V2 flag set', async () => {
-    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken(
+      'fake-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    );
     const T = componentsV2Edit;
-    const t = new T({ name: 'components_v2_edit', path: 'inline', root: 'inline', store: null as never }, { name: 'components_v2_edit', enabled: true });
+    const t = new T(
+      { name: 'components_v2_edit', path: 'inline', root: 'inline', store: null as never },
+      { name: 'components_v2_edit', enabled: true },
+    );
     const r = (await t.run(
       {
         channel_id: '111122223333444455',

--- a/packages/mcp-core/src/tools/components-v2/edit.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/edit.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { REST } from '@discordjs/rest';
+import { container } from '@sapphire/pieces';
+import componentsV2Edit from './edit.js';
+import '../../container.js';
+
+describe('components_v2_edit', () => {
+  it('edits with V2 flag set', async () => {
+    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    const T = componentsV2Edit;
+    const t = new T({ name: 'components_v2_edit', path: 'inline', root: 'inline', store: null as never }, { name: 'components_v2_edit', enabled: true });
+    const r = (await t.run(
+      {
+        channel_id: '111122223333444455',
+        message_id: '999000999000999000',
+        components: [{ type: 10, content: 'updated' }],
+      },
+      { signal: new AbortController().signal },
+    )) as { isError: boolean; structuredContent: { message_id: string; edited_timestamp: string } };
+    expect(r.isError).toBe(false);
+    expect(r.structuredContent.message_id).toBe('999000999000999000');
+  });
+});

--- a/packages/mcp-core/src/tools/components-v2/edit.ts
+++ b/packages/mcp-core/src/tools/components-v2/edit.ts
@@ -1,11 +1,11 @@
-import { z } from 'zod';
-import { Routes } from 'discord-api-types/v10';
 import { container } from '@sapphire/pieces';
-import { defineTool } from '../_lib/defineTool.js';
-import { ChannelId, MessageId } from '../_lib/snowflake.js';
-import { dualResult } from '../_lib/response.js';
-import { validateComponentsV2 } from './_lib/validator.js';
+import { Routes } from 'discord-api-types/v10';
+import { z } from 'zod';
 import { ValidationError } from '../../errors/client.js';
+import { defineTool } from '../_lib/defineTool.js';
+import { dualResult } from '../_lib/response.js';
+import { ChannelId, MessageId } from '../_lib/snowflake.js';
+import { validateComponentsV2 } from './_lib/validator.js';
 
 const IS_COMPONENTS_V2 = 1 << 15;
 
@@ -24,11 +24,18 @@ export default defineTool({
     channel_id: ChannelId,
     edited_timestamp: z.string(),
   },
-  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
   handler: async (args) => {
     const validation = validateComponentsV2(args.components);
     if (!validation.valid) {
-      throw new ValidationError(validation.issues.map((i) => ({ path: i.path, message: i.message, code: i.code })));
+      throw new ValidationError(
+        validation.issues.map((i) => ({ path: i.path, message: i.message, code: i.code })),
+      );
     }
     const m = (await container.rest.patch(Routes.channelMessage(args.channel_id, args.message_id), {
       body: { flags: IS_COMPONENTS_V2, components: args.components },

--- a/packages/mcp-core/src/tools/components-v2/edit.ts
+++ b/packages/mcp-core/src/tools/components-v2/edit.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import { Routes } from 'discord-api-types/v10';
+import { container } from '@sapphire/pieces';
+import { defineTool } from '../_lib/defineTool.js';
+import { ChannelId, MessageId } from '../_lib/snowflake.js';
+import { dualResult } from '../_lib/response.js';
+import { validateComponentsV2 } from './_lib/validator.js';
+import { ValidationError } from '../../errors/client.js';
+
+const IS_COMPONENTS_V2 = 1 << 15;
+
+export default defineTool({
+  name: 'components_v2_edit',
+  category: 'components_v2',
+  description:
+    '**Purpose**: Edit a Components V2 message previously sent by this bot. The `IS_COMPONENTS_V2` flag is irreversible — V2 messages stay V2.\n\n**Returns**: `{message_id, channel_id, edited_timestamp}`.',
+  inputSchema: {
+    channel_id: ChannelId,
+    message_id: MessageId,
+    components: z.array(z.unknown()).min(1).max(40),
+  },
+  outputSchema: {
+    message_id: MessageId,
+    channel_id: ChannelId,
+    edited_timestamp: z.string(),
+  },
+  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+  handler: async (args) => {
+    const validation = validateComponentsV2(args.components);
+    if (!validation.valid) {
+      throw new ValidationError(validation.issues.map((i) => ({ path: i.path, message: i.message, code: i.code })));
+    }
+    const m = (await container.rest.patch(Routes.channelMessage(args.channel_id, args.message_id), {
+      body: { flags: IS_COMPONENTS_V2, components: args.components },
+    })) as { id: string; channel_id: string; edited_timestamp: string };
+    return dualResult({
+      text: `Edited V2 message ${m.id} in <#${m.channel_id}>.`,
+      data: { message_id: m.id, channel_id: m.channel_id, edited_timestamp: m.edited_timestamp },
+    });
+  },
+});

--- a/packages/mcp-core/src/tools/components-v2/preview-tool.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/preview-tool.test.ts
@@ -1,11 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import preview from './preview-tool.js';
 
 describe('components_v2_preview tool', () => {
   it('renders ASCII for a TextDisplay', async () => {
     const T = preview;
-    const t = new T({ name: 'components_v2_preview', path: 'inline', root: 'inline', store: null as never }, { name: 'components_v2_preview', enabled: true });
-    const r = (await t.run({ components: [{ type: 10, content: 'hello' }] }, { signal: new AbortController().signal })) as {
+    const t = new T(
+      { name: 'components_v2_preview', path: 'inline', root: 'inline', store: null as never },
+      { name: 'components_v2_preview', enabled: true },
+    );
+    const r = (await t.run(
+      { components: [{ type: 10, content: 'hello' }] },
+      { signal: new AbortController().signal },
+    )) as {
       isError: boolean;
       structuredContent: { ascii: string };
     };

--- a/packages/mcp-core/src/tools/components-v2/preview-tool.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/preview-tool.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import preview from './preview-tool.js';
+
+describe('components_v2_preview tool', () => {
+  it('renders ASCII for a TextDisplay', async () => {
+    const T = preview;
+    const t = new T({ name: 'components_v2_preview', path: 'inline', root: 'inline', store: null as never }, { name: 'components_v2_preview', enabled: true });
+    const r = (await t.run({ components: [{ type: 10, content: 'hello' }] }, { signal: new AbortController().signal })) as {
+      isError: boolean;
+      structuredContent: { ascii: string };
+    };
+    expect(r.isError).toBe(false);
+    expect(r.structuredContent.ascii).toContain('hello');
+  });
+});

--- a/packages/mcp-core/src/tools/components-v2/preview-tool.ts
+++ b/packages/mcp-core/src/tools/components-v2/preview-tool.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import { defineTool } from '../_lib/defineTool.js';
+import { dualResult } from '../_lib/response.js';
+import { renderPreview } from './_lib/preview.js';
+
+export default defineTool({
+  name: 'components_v2_preview',
+  category: 'components_v2',
+  description:
+    '**Purpose**: Render a Components V2 layout as ASCII so the agent can sanity-check structure without sending. Pairs with `components_v2_validate` for offline iteration.\n\n**Returns**: `{ascii}` — multi-line string visualizing the layout.',
+  inputSchema: {
+    components: z.array(z.unknown()).describe('Components array to render'),
+  },
+  outputSchema: {
+    ascii: z.string(),
+  },
+  annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  idempotent: true,
+  handler: async (args) => {
+    const ascii = renderPreview(args.components as never);
+    return dualResult({ text: '```\n' + ascii + '\n```', data: { ascii } });
+  },
+});

--- a/packages/mcp-core/src/tools/components-v2/preview-tool.ts
+++ b/packages/mcp-core/src/tools/components-v2/preview-tool.ts
@@ -14,7 +14,12 @@ export default defineTool({
   outputSchema: {
     ascii: z.string(),
   },
-  annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   idempotent: true,
   handler: async (args) => {
     const ascii = renderPreview(args.components as never);

--- a/packages/mcp-core/src/tools/components-v2/send-from-template.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/send-from-template.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { REST } from '@discordjs/rest';
+import { container } from '@sapphire/pieces';
+import sendFromTemplate from './send-from-template.js';
+import '../../container.js';
+
+describe('components_v2_send_from_template', () => {
+  it('applies announcement template variables and sends', async () => {
+    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    const T = sendFromTemplate;
+    const t = new T({ name: 'components_v2_send_from_template', path: 'inline', root: 'inline', store: null as never }, { name: 'components_v2_send_from_template', enabled: true });
+    const r = (await t.run(
+      {
+        channel_id: '112233445566778899',
+        template: 'announcement',
+        vars: { title: 'Hello', body: 'world', cta_label: 'Click', cta_url: 'https://example.com' },
+      },
+      { signal: new AbortController().signal },
+    )) as { isError: boolean; structuredContent: { message_id: string; template: string } };
+    expect(r.isError).toBe(false);
+    expect(r.structuredContent.message_id).toBe('999000999000999000');
+    expect(r.structuredContent.template).toBe('announcement');
+  });
+});

--- a/packages/mcp-core/src/tools/components-v2/send-from-template.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/send-from-template.test.ts
@@ -1,14 +1,24 @@
-import { describe, it, expect } from 'vitest';
 import { REST } from '@discordjs/rest';
 import { container } from '@sapphire/pieces';
+import { describe, expect, it } from 'vitest';
 import sendFromTemplate from './send-from-template.js';
 import '../../container.js';
 
 describe('components_v2_send_from_template', () => {
   it('applies announcement template variables and sends', async () => {
-    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken(
+      'fake-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    );
     const T = sendFromTemplate;
-    const t = new T({ name: 'components_v2_send_from_template', path: 'inline', root: 'inline', store: null as never }, { name: 'components_v2_send_from_template', enabled: true });
+    const t = new T(
+      {
+        name: 'components_v2_send_from_template',
+        path: 'inline',
+        root: 'inline',
+        store: null as never,
+      },
+      { name: 'components_v2_send_from_template', enabled: true },
+    );
     const r = (await t.run(
       {
         channel_id: '112233445566778899',

--- a/packages/mcp-core/src/tools/components-v2/send-from-template.ts
+++ b/packages/mcp-core/src/tools/components-v2/send-from-template.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Routes } from 'discord-api-types/v10';
+import { container } from '@sapphire/pieces';
+import { defineTool } from '../_lib/defineTool.js';
+import { ChannelId, MessageId } from '../_lib/snowflake.js';
+import { dualResult } from '../_lib/response.js';
+import { interpolateTemplate } from './_lib/interpolate.js';
+import { validateComponentsV2 } from './_lib/validator.js';
+import { ValidationError, DiscordNotFoundError } from '../../errors/client.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const TEMPLATES_DIR = join(__dirname, 'templates');
+const IS_COMPONENTS_V2 = 1 << 15;
+
+const KNOWN_TEMPLATES = ['announcement', 'release_notes', 'welcome_card', 'poll_results', 'incident_status'] as const;
+
+interface TemplateFile {
+  name: string;
+  description: string;
+  variables: string[];
+  components: unknown[];
+}
+
+export default defineTool({
+  name: 'components_v2_send_from_template',
+  category: 'components_v2',
+  description:
+    '**Purpose**: Apply variables to a built-in V2 template and send the result.\n\n**Templates v1**: announcement, release_notes, welcome_card, poll_results, incident_status. Each declares a `variables` list — pass values in `vars`.\n\n**Returns**: `{message_id, jump_url, template}`.',
+  inputSchema: {
+    channel_id: ChannelId,
+    template: z.enum(KNOWN_TEMPLATES).describe('Built-in template name'),
+    vars: z.record(z.string(), z.string()).describe('Variable substitutions for {{...}} placeholders'),
+  },
+  outputSchema: {
+    message_id: MessageId,
+    channel_id: ChannelId,
+    jump_url: z.string().url(),
+    template: z.string(),
+  },
+  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+  handler: async (args) => {
+    const path = join(TEMPLATES_DIR, `${args.template}.json`);
+    let raw: string;
+    try {
+      raw = await readFile(path, 'utf8');
+    } catch {
+      throw new DiscordNotFoundError('template', args.template);
+    }
+    const parsed = JSON.parse(raw) as TemplateFile;
+    const components = interpolateTemplate(parsed.components, args.vars);
+    const validation = validateComponentsV2(components);
+    if (!validation.valid) {
+      throw new ValidationError(validation.issues.map((i) => ({ path: i.path, message: i.message, code: i.code })));
+    }
+    const m = (await container.rest.post(Routes.channelMessages(args.channel_id), {
+      body: { flags: IS_COMPONENTS_V2, components },
+    })) as { id: string; channel_id: string; guild_id?: string };
+    const jumpRoot = m.guild_id ?? '@me';
+    return dualResult({
+      text: `Sent template "${args.template}" as message ${m.id} to <#${m.channel_id}>.`,
+      data: {
+        message_id: m.id,
+        channel_id: m.channel_id,
+        jump_url: `https://discord.com/channels/${jumpRoot}/${m.channel_id}/${m.id}`,
+        template: args.template,
+      },
+    });
+  },
+});

--- a/packages/mcp-core/src/tools/components-v2/send-from-template.ts
+++ b/packages/mcp-core/src/tools/components-v2/send-from-template.ts
@@ -1,22 +1,28 @@
-import { z } from 'zod';
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Routes } from 'discord-api-types/v10';
 import { container } from '@sapphire/pieces';
+import { Routes } from 'discord-api-types/v10';
+import { z } from 'zod';
+import { DiscordNotFoundError, ValidationError } from '../../errors/client.js';
 import { defineTool } from '../_lib/defineTool.js';
-import { ChannelId, MessageId } from '../_lib/snowflake.js';
 import { dualResult } from '../_lib/response.js';
+import { ChannelId, MessageId } from '../_lib/snowflake.js';
 import { interpolateTemplate } from './_lib/interpolate.js';
 import { validateComponentsV2 } from './_lib/validator.js';
-import { ValidationError, DiscordNotFoundError } from '../../errors/client.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const TEMPLATES_DIR = join(__dirname, 'templates');
 const IS_COMPONENTS_V2 = 1 << 15;
 
-const KNOWN_TEMPLATES = ['announcement', 'release_notes', 'welcome_card', 'poll_results', 'incident_status'] as const;
+const KNOWN_TEMPLATES = [
+  'announcement',
+  'release_notes',
+  'welcome_card',
+  'poll_results',
+  'incident_status',
+] as const;
 
 interface TemplateFile {
   name: string;
@@ -33,7 +39,9 @@ export default defineTool({
   inputSchema: {
     channel_id: ChannelId,
     template: z.enum(KNOWN_TEMPLATES).describe('Built-in template name'),
-    vars: z.record(z.string(), z.string()).describe('Variable substitutions for {{...}} placeholders'),
+    vars: z
+      .record(z.string(), z.string())
+      .describe('Variable substitutions for {{...}} placeholders'),
   },
   outputSchema: {
     message_id: MessageId,
@@ -41,7 +49,12 @@ export default defineTool({
     jump_url: z.string().url(),
     template: z.string(),
   },
-  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
   handler: async (args) => {
     const path = join(TEMPLATES_DIR, `${args.template}.json`);
     let raw: string;
@@ -54,7 +67,9 @@ export default defineTool({
     const components = interpolateTemplate(parsed.components, args.vars);
     const validation = validateComponentsV2(components);
     if (!validation.valid) {
-      throw new ValidationError(validation.issues.map((i) => ({ path: i.path, message: i.message, code: i.code })));
+      throw new ValidationError(
+        validation.issues.map((i) => ({ path: i.path, message: i.message, code: i.code })),
+      );
     }
     const m = (await container.rest.post(Routes.channelMessages(args.channel_id), {
       body: { flags: IS_COMPONENTS_V2, components },

--- a/packages/mcp-core/src/tools/components-v2/send.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/send.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { REST } from '@discordjs/rest';
+import { container } from '@sapphire/pieces';
+import componentsV2Send from './send.js';
+import '../../container.js';
+
+describe('components_v2_send', () => {
+  it('sets IS_COMPONENTS_V2 flag and returns message_id', async () => {
+    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    const T = componentsV2Send;
+    const t = new T({ name: 'components_v2_send', path: 'inline', root: 'inline', store: null as never }, { name: 'components_v2_send', enabled: true });
+    const r = (await t.run(
+      {
+        channel_id: '112233445566778899',
+        components: [{ type: 10, content: 'hi from V2' }],
+      },
+      { signal: new AbortController().signal },
+    )) as { isError: boolean; structuredContent: { message_id: string; channel_id: string; component_count: number; jump_url: string } };
+    expect(r.isError).toBe(false);
+    expect(r.structuredContent.message_id).toBe('999000999000999000');
+    expect(r.structuredContent.component_count).toBe(1);
+    expect(r.structuredContent.jump_url).toMatch(/discord\.com\/channels/);
+  });
+
+  it('rejects invalid layout offline (does not call Discord)', async () => {
+    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake');
+    const T = componentsV2Send;
+    const t = new T({ name: 'components_v2_send', path: 'inline', root: 'inline', store: null as never }, { name: 'components_v2_send', enabled: true });
+    // Container nested in Container is invalid
+    await expect(
+      t.run(
+        {
+          channel_id: '112233445566778899',
+          components: [{ type: 17, components: [{ type: 17, components: [{ type: 10, content: 'inner' }] }] }],
+        },
+        { signal: new AbortController().signal },
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/mcp-core/src/tools/components-v2/send.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/send.test.ts
@@ -1,21 +1,34 @@
-import { describe, it, expect } from 'vitest';
 import { REST } from '@discordjs/rest';
 import { container } from '@sapphire/pieces';
+import { describe, expect, it } from 'vitest';
 import componentsV2Send from './send.js';
 import '../../container.js';
 
 describe('components_v2_send', () => {
   it('sets IS_COMPONENTS_V2 flag and returns message_id', async () => {
-    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken(
+      'fake-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    );
     const T = componentsV2Send;
-    const t = new T({ name: 'components_v2_send', path: 'inline', root: 'inline', store: null as never }, { name: 'components_v2_send', enabled: true });
+    const t = new T(
+      { name: 'components_v2_send', path: 'inline', root: 'inline', store: null as never },
+      { name: 'components_v2_send', enabled: true },
+    );
     const r = (await t.run(
       {
         channel_id: '112233445566778899',
         components: [{ type: 10, content: 'hi from V2' }],
       },
       { signal: new AbortController().signal },
-    )) as { isError: boolean; structuredContent: { message_id: string; channel_id: string; component_count: number; jump_url: string } };
+    )) as {
+      isError: boolean;
+      structuredContent: {
+        message_id: string;
+        channel_id: string;
+        component_count: number;
+        jump_url: string;
+      };
+    };
     expect(r.isError).toBe(false);
     expect(r.structuredContent.message_id).toBe('999000999000999000');
     expect(r.structuredContent.component_count).toBe(1);
@@ -25,13 +38,18 @@ describe('components_v2_send', () => {
   it('rejects invalid layout offline (does not call Discord)', async () => {
     container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake');
     const T = componentsV2Send;
-    const t = new T({ name: 'components_v2_send', path: 'inline', root: 'inline', store: null as never }, { name: 'components_v2_send', enabled: true });
+    const t = new T(
+      { name: 'components_v2_send', path: 'inline', root: 'inline', store: null as never },
+      { name: 'components_v2_send', enabled: true },
+    );
     // Container nested in Container is invalid
     await expect(
       t.run(
         {
           channel_id: '112233445566778899',
-          components: [{ type: 17, components: [{ type: 17, components: [{ type: 10, content: 'inner' }] }] }],
+          components: [
+            { type: 17, components: [{ type: 17, components: [{ type: 10, content: 'inner' }] }] },
+          ],
         },
         { signal: new AbortController().signal },
       ),

--- a/packages/mcp-core/src/tools/components-v2/send.ts
+++ b/packages/mcp-core/src/tools/components-v2/send.ts
@@ -1,11 +1,11 @@
-import { z } from 'zod';
-import { Routes } from 'discord-api-types/v10';
 import { container } from '@sapphire/pieces';
-import { defineTool } from '../_lib/defineTool.js';
-import { ChannelId, MessageId } from '../_lib/snowflake.js';
-import { dualResult } from '../_lib/response.js';
-import { validateComponentsV2 } from './_lib/validator.js';
+import { Routes } from 'discord-api-types/v10';
+import { z } from 'zod';
 import { ValidationError } from '../../errors/client.js';
+import { defineTool } from '../_lib/defineTool.js';
+import { dualResult } from '../_lib/response.js';
+import { ChannelId, MessageId } from '../_lib/snowflake.js';
+import { validateComponentsV2 } from './_lib/validator.js';
 
 const IS_COMPONENTS_V2 = 1 << 15;
 
@@ -23,7 +23,11 @@ export default defineTool({
     '**Purpose**: Send a Components V2 message — rich layout (Container, Section, MediaGallery, ActionRow, ...). MUTUALLY EXCLUSIVE with content/embed/poll/sticker. Flag `IS_COMPONENTS_V2` is irreversible per-message.\n\n**When to use**: announcements, release notes, dashboards, polls — anything beyond plain text.\n\n**When NOT to use**: simple text reply → use `messages_send`.\n\n**Validation**: components are validated via `validateComponentsV2` before sending; the call rejects with VALIDATION_FAILED if the layout is illegal (no API call made).\n\n**Returns**: `{message_id, channel_id, jump_url, component_count}`.',
   inputSchema: {
     channel_id: ChannelId.describe('Target channel'),
-    components: z.array(z.unknown()).min(1).max(40).describe('Components V2 array (1-40 items, recursive)'),
+    components: z
+      .array(z.unknown())
+      .min(1)
+      .max(40)
+      .describe('Components V2 array (1-40 items, recursive)'),
     allowed_mentions: z
       .object({
         parse: z.array(z.enum(['users', 'roles', 'everyone'])).optional(),
@@ -38,18 +42,27 @@ export default defineTool({
     jump_url: z.string().url(),
     component_count: z.number().int(),
   },
-  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
   handler: async (args) => {
     const validation = validateComponentsV2(args.components);
     if (!validation.valid) {
-      throw new ValidationError(validation.issues.map((i) => ({ path: i.path, message: i.message, code: i.code })));
+      throw new ValidationError(
+        validation.issues.map((i) => ({ path: i.path, message: i.message, code: i.code })),
+      );
     }
     const body: Record<string, unknown> = {
       flags: IS_COMPONENTS_V2,
       components: args.components,
     };
     if (args.allowed_mentions !== undefined) body['allowed_mentions'] = args.allowed_mentions;
-    const m = (await container.rest.post(Routes.channelMessages(args.channel_id), { body })) as SentMessage;
+    const m = (await container.rest.post(Routes.channelMessages(args.channel_id), {
+      body,
+    })) as SentMessage;
     const jumpRoot = m.guild_id ?? '@me';
     return dualResult({
       text: `Sent V2 message ${m.id} to <#${m.channel_id}> (${args.components.length} top-level components).`,

--- a/packages/mcp-core/src/tools/components-v2/send.ts
+++ b/packages/mcp-core/src/tools/components-v2/send.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import { Routes } from 'discord-api-types/v10';
+import { container } from '@sapphire/pieces';
+import { defineTool } from '../_lib/defineTool.js';
+import { ChannelId, MessageId } from '../_lib/snowflake.js';
+import { dualResult } from '../_lib/response.js';
+import { validateComponentsV2 } from './_lib/validator.js';
+import { ValidationError } from '../../errors/client.js';
+
+const IS_COMPONENTS_V2 = 1 << 15;
+
+interface SentMessage {
+  id: string;
+  channel_id: string;
+  flags?: number;
+  guild_id?: string;
+}
+
+export default defineTool({
+  name: 'components_v2_send',
+  category: 'components_v2',
+  description:
+    '**Purpose**: Send a Components V2 message — rich layout (Container, Section, MediaGallery, ActionRow, ...). MUTUALLY EXCLUSIVE with content/embed/poll/sticker. Flag `IS_COMPONENTS_V2` is irreversible per-message.\n\n**When to use**: announcements, release notes, dashboards, polls — anything beyond plain text.\n\n**When NOT to use**: simple text reply → use `messages_send`.\n\n**Validation**: components are validated via `validateComponentsV2` before sending; the call rejects with VALIDATION_FAILED if the layout is illegal (no API call made).\n\n**Returns**: `{message_id, channel_id, jump_url, component_count}`.',
+  inputSchema: {
+    channel_id: ChannelId.describe('Target channel'),
+    components: z.array(z.unknown()).min(1).max(40).describe('Components V2 array (1-40 items, recursive)'),
+    allowed_mentions: z
+      .object({
+        parse: z.array(z.enum(['users', 'roles', 'everyone'])).optional(),
+        users: z.array(z.string()).optional(),
+        roles: z.array(z.string()).optional(),
+      })
+      .optional(),
+  },
+  outputSchema: {
+    message_id: MessageId,
+    channel_id: ChannelId,
+    jump_url: z.string().url(),
+    component_count: z.number().int(),
+  },
+  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+  handler: async (args) => {
+    const validation = validateComponentsV2(args.components);
+    if (!validation.valid) {
+      throw new ValidationError(validation.issues.map((i) => ({ path: i.path, message: i.message, code: i.code })));
+    }
+    const body: Record<string, unknown> = {
+      flags: IS_COMPONENTS_V2,
+      components: args.components,
+    };
+    if (args.allowed_mentions !== undefined) body['allowed_mentions'] = args.allowed_mentions;
+    const m = (await container.rest.post(Routes.channelMessages(args.channel_id), { body })) as SentMessage;
+    const jumpRoot = m.guild_id ?? '@me';
+    return dualResult({
+      text: `Sent V2 message ${m.id} to <#${m.channel_id}> (${args.components.length} top-level components).`,
+      data: {
+        message_id: m.id,
+        channel_id: m.channel_id,
+        jump_url: `https://discord.com/channels/${jumpRoot}/${m.channel_id}/${m.id}`,
+        component_count: args.components.length,
+      },
+    });
+  },
+});

--- a/packages/mcp-core/src/tools/components-v2/templates/announcement.json
+++ b/packages/mcp-core/src/tools/components-v2/templates/announcement.json
@@ -17,9 +17,7 @@
         { "type": 14, "divider": true, "spacing": 1 },
         {
           "type": 1,
-          "components": [
-            { "type": 2, "style": 5, "label": "{{cta_label}}", "url": "{{cta_url}}" }
-          ]
+          "components": [{ "type": 2, "style": 5, "label": "{{cta_label}}", "url": "{{cta_url}}" }]
         }
       ]
     }

--- a/packages/mcp-core/src/tools/components-v2/templates/announcement.json
+++ b/packages/mcp-core/src/tools/components-v2/templates/announcement.json
@@ -1,0 +1,27 @@
+{
+  "name": "announcement",
+  "description": "Single Container with title, body paragraph, and CTA button",
+  "variables": ["title", "body", "cta_label", "cta_url"],
+  "components": [
+    {
+      "type": 17,
+      "accent_color": 5793266,
+      "components": [
+        {
+          "type": 9,
+          "components": [
+            { "type": 10, "content": "## {{title}}" },
+            { "type": 10, "content": "{{body}}" }
+          ]
+        },
+        { "type": 14, "divider": true, "spacing": 1 },
+        {
+          "type": 1,
+          "components": [
+            { "type": 2, "style": 5, "label": "{{cta_label}}", "url": "{{cta_url}}" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/mcp-core/src/tools/components-v2/templates/incident_status.json
+++ b/packages/mcp-core/src/tools/components-v2/templates/incident_status.json
@@ -1,0 +1,28 @@
+{
+  "name": "incident_status",
+  "description": "Status indicator + affected services + status update buttons",
+  "variables": ["status_emoji", "title", "summary", "ack_custom_id", "resolve_custom_id"],
+  "components": [
+    {
+      "type": 17,
+      "accent_color": 16711680,
+      "components": [
+        {
+          "type": 9,
+          "components": [
+            { "type": 10, "content": "{{status_emoji}} **{{title}}**" },
+            { "type": 10, "content": "{{summary}}" }
+          ]
+        },
+        { "type": 14, "divider": true, "spacing": 1 },
+        {
+          "type": 1,
+          "components": [
+            { "type": 2, "style": 1, "label": "Acknowledge", "custom_id": "{{ack_custom_id}}" },
+            { "type": 2, "style": 3, "label": "Resolve", "custom_id": "{{resolve_custom_id}}" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/mcp-core/src/tools/components-v2/templates/poll_results.json
+++ b/packages/mcp-core/src/tools/components-v2/templates/poll_results.json
@@ -1,0 +1,22 @@
+{
+  "name": "poll_results",
+  "description": "Poll question + bar-chart-as-text + winner highlight",
+  "variables": ["question", "bars_text", "winner"],
+  "components": [
+    {
+      "type": 17,
+      "accent_color": 16776960,
+      "components": [
+        {
+          "type": 9,
+          "components": [
+            { "type": 10, "content": "## Poll: {{question}}" },
+            { "type": 10, "content": "{{bars_text}}" }
+          ]
+        },
+        { "type": 14, "divider": true, "spacing": 1 },
+        { "type": 10, "content": "**Winner**: {{winner}}" }
+      ]
+    }
+  ]
+}

--- a/packages/mcp-core/src/tools/components-v2/templates/release_notes.json
+++ b/packages/mcp-core/src/tools/components-v2/templates/release_notes.json
@@ -1,0 +1,28 @@
+{
+  "name": "release_notes",
+  "description": "Container with version header, changelog sections, optional download buttons",
+  "variables": ["version", "headline", "changelog", "download_url"],
+  "components": [
+    {
+      "type": 17,
+      "accent_color": 65280,
+      "components": [
+        {
+          "type": 9,
+          "components": [
+            { "type": 10, "content": "# Release {{version}}" },
+            { "type": 10, "content": "{{headline}}" }
+          ]
+        },
+        { "type": 14, "divider": true, "spacing": 1 },
+        { "type": 10, "content": "{{changelog}}" },
+        {
+          "type": 1,
+          "components": [
+            { "type": 2, "style": 5, "label": "Download", "url": "{{download_url}}" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/mcp-core/src/tools/components-v2/templates/release_notes.json
+++ b/packages/mcp-core/src/tools/components-v2/templates/release_notes.json
@@ -18,9 +18,7 @@
         { "type": 10, "content": "{{changelog}}" },
         {
           "type": 1,
-          "components": [
-            { "type": 2, "style": 5, "label": "Download", "url": "{{download_url}}" }
-          ]
+          "components": [{ "type": 2, "style": 5, "label": "Download", "url": "{{download_url}}" }]
         }
       ]
     }

--- a/packages/mcp-core/src/tools/components-v2/templates/welcome_card.json
+++ b/packages/mcp-core/src/tools/components-v2/templates/welcome_card.json
@@ -1,0 +1,30 @@
+{
+  "name": "welcome_card",
+  "description": "Welcome new member with avatar thumbnail + role-claim button",
+  "variables": ["username", "avatar_url", "role_id_member", "rules_channel_id"],
+  "components": [
+    {
+      "type": 17,
+      "accent_color": 16711935,
+      "components": [
+        {
+          "type": 9,
+          "components": [
+            { "type": 10, "content": "## Welcome, {{username}}!" },
+            { "type": 10, "content": "Read the rules in <#{{rules_channel_id}}> then claim your role below." }
+          ],
+          "accessory": {
+            "type": 11,
+            "media": { "url": "{{avatar_url}}" }
+          }
+        },
+        {
+          "type": 1,
+          "components": [
+            { "type": 2, "style": 3, "label": "Claim Member", "custom_id": "welcome_claim_{{role_id_member}}" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/mcp-core/src/tools/components-v2/templates/welcome_card.json
+++ b/packages/mcp-core/src/tools/components-v2/templates/welcome_card.json
@@ -11,7 +11,10 @@
           "type": 9,
           "components": [
             { "type": 10, "content": "## Welcome, {{username}}!" },
-            { "type": 10, "content": "Read the rules in <#{{rules_channel_id}}> then claim your role below." }
+            {
+              "type": 10,
+              "content": "Read the rules in <#{{rules_channel_id}}> then claim your role below."
+            }
           ],
           "accessory": {
             "type": 11,
@@ -21,7 +24,12 @@
         {
           "type": 1,
           "components": [
-            { "type": 2, "style": 3, "label": "Claim Member", "custom_id": "welcome_claim_{{role_id_member}}" }
+            {
+              "type": 2,
+              "style": 3,
+              "label": "Claim Member",
+              "custom_id": "welcome_claim_{{role_id_member}}"
+            }
           ]
         }
       ]

--- a/packages/mcp-core/src/tools/components-v2/validate.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/validate.test.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import componentsV2Validate from './validate.js';
 
 describe('components_v2_validate', () => {
   it('returns valid:true for a sound layout', async () => {
     const T = componentsV2Validate;
-    const t = new T({ name: 'components_v2_validate', path: 'inline', root: 'inline', store: null as never }, { name: 'components_v2_validate', enabled: true });
+    const t = new T(
+      { name: 'components_v2_validate', path: 'inline', root: 'inline', store: null as never },
+      { name: 'components_v2_validate', enabled: true },
+    );
     const r = (await t.run(
       { components: [{ type: 10, content: 'hi' }] },
       { signal: new AbortController().signal },
@@ -16,11 +19,21 @@ describe('components_v2_validate', () => {
 
   it('reports issues for invalid layout', async () => {
     const T = componentsV2Validate;
-    const t = new T({ name: 'components_v2_validate', path: 'inline', root: 'inline', store: null as never }, { name: 'components_v2_validate', enabled: true });
+    const t = new T(
+      { name: 'components_v2_validate', path: 'inline', root: 'inline', store: null as never },
+      { name: 'components_v2_validate', enabled: true },
+    );
     const r = (await t.run(
-      { components: [{ type: 17, components: [{ type: 17, components: [{ type: 10, content: 'inner' }] }] }] },
+      {
+        components: [
+          { type: 17, components: [{ type: 17, components: [{ type: 10, content: 'inner' }] }] },
+        ],
+      },
       { signal: new AbortController().signal },
-    )) as { isError: boolean; structuredContent: { valid: boolean; issues: Array<{ code: string }> } };
+    )) as {
+      isError: boolean;
+      structuredContent: { valid: boolean; issues: Array<{ code: string }> };
+    };
     expect(r.structuredContent.valid).toBe(false);
     expect(r.structuredContent.issues.some((i) => i.code === 'CONTAINER_IN_CONTAINER')).toBe(true);
   });

--- a/packages/mcp-core/src/tools/components-v2/validate.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/validate.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import componentsV2Validate from './validate.js';
+
+describe('components_v2_validate', () => {
+  it('returns valid:true for a sound layout', async () => {
+    const T = componentsV2Validate;
+    const t = new T({ name: 'components_v2_validate', path: 'inline', root: 'inline', store: null as never }, { name: 'components_v2_validate', enabled: true });
+    const r = (await t.run(
+      { components: [{ type: 10, content: 'hi' }] },
+      { signal: new AbortController().signal },
+    )) as { isError: boolean; structuredContent: { valid: boolean; issues: unknown[] } };
+    expect(r.isError).toBe(false);
+    expect(r.structuredContent.valid).toBe(true);
+    expect(r.structuredContent.issues).toEqual([]);
+  });
+
+  it('reports issues for invalid layout', async () => {
+    const T = componentsV2Validate;
+    const t = new T({ name: 'components_v2_validate', path: 'inline', root: 'inline', store: null as never }, { name: 'components_v2_validate', enabled: true });
+    const r = (await t.run(
+      { components: [{ type: 17, components: [{ type: 17, components: [{ type: 10, content: 'inner' }] }] }] },
+      { signal: new AbortController().signal },
+    )) as { isError: boolean; structuredContent: { valid: boolean; issues: Array<{ code: string }> } };
+    expect(r.structuredContent.valid).toBe(false);
+    expect(r.structuredContent.issues.some((i) => i.code === 'CONTAINER_IN_CONTAINER')).toBe(true);
+  });
+});

--- a/packages/mcp-core/src/tools/components-v2/validate.ts
+++ b/packages/mcp-core/src/tools/components-v2/validate.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { defineTool } from '../_lib/defineTool.js';
+import { dualResult } from '../_lib/response.js';
+import { validateComponentsV2 } from './_lib/validator.js';
+
+export default defineTool({
+  name: 'components_v2_validate',
+  category: 'components_v2',
+  description:
+    '**Purpose**: Validate a Components V2 components array OFFLINE (no Discord API call). Catches 40-cap, nesting violations, accessory mismatches, MediaGallery range, Button missing custom_id/url.\n\n**When to use**: iterate on a layout before sending. Saves round-trips for agents constructing complex cards.\n\n**Returns**: `{valid, issues:[{path, code, message, fix_hint?}]}`.',
+  inputSchema: {
+    components: z.array(z.unknown()).describe('Components array (will be validated)'),
+  },
+  outputSchema: {
+    valid: z.boolean(),
+    issues: z.array(
+      z.object({
+        path: z.string(),
+        code: z.string(),
+        message: z.string(),
+        fix_hint: z.string().optional(),
+      }),
+    ),
+  },
+  annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  idempotent: true,
+  handler: async (args) => {
+    const result = validateComponentsV2(args.components);
+    const lines = result.valid
+      ? '_Layout is valid._'
+      : result.issues
+          .map(
+            (i) =>
+              `- \`${i.path}\` **${i.code}**: ${i.message}${i.fix_hint !== undefined ? ` _(${i.fix_hint})_` : ''}`,
+          )
+          .join('\n');
+    return dualResult({
+      text: `**Components V2 validation**: ${result.valid ? '✅ valid' : `❌ ${result.issues.length} issue(s)`}\n${lines}`,
+      data: { valid: result.valid, issues: result.issues.map((i) => ({ ...i })) },
+    });
+  },
+});

--- a/packages/mcp-core/src/tools/components-v2/validate.ts
+++ b/packages/mcp-core/src/tools/components-v2/validate.ts
@@ -22,7 +22,12 @@ export default defineTool({
       }),
     ),
   },
-  annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   idempotent: true,
   handler: async (args) => {
     const result = validateComponentsV2(args.components);

--- a/test/mocks/discord-handlers.ts
+++ b/test/mocks/discord-handlers.ts
@@ -5,7 +5,12 @@ const DISCORD_API = 'https://discord.com/api/v10';
 export const handlers = [
   // Default: messages_send happy path
   http.post(`${DISCORD_API}/channels/:channelId/messages`, async ({ params, request }) => {
-    const body = (await request.json()) as { content?: string; tts?: boolean; flags?: number; components?: unknown[] };
+    const body = (await request.json()) as {
+      content?: string;
+      tts?: boolean;
+      flags?: number;
+      components?: unknown[];
+    };
     return HttpResponse.json({
       id: '999000999000999000',
       channel_id: params['channelId'],
@@ -216,7 +221,11 @@ export const handlers = [
   http.patch(
     `${DISCORD_API}/channels/:channelId/messages/:messageId`,
     async ({ params, request }) => {
-      const body = (await request.json()) as { content?: string; flags?: number; components?: unknown[] };
+      const body = (await request.json()) as {
+        content?: string;
+        flags?: number;
+        components?: unknown[];
+      };
       return HttpResponse.json({
         id: params['messageId'],
         channel_id: params['channelId'],

--- a/test/mocks/discord-handlers.ts
+++ b/test/mocks/discord-handlers.ts
@@ -5,15 +5,17 @@ const DISCORD_API = 'https://discord.com/api/v10';
 export const handlers = [
   // Default: messages_send happy path
   http.post(`${DISCORD_API}/channels/:channelId/messages`, async ({ params, request }) => {
-    const body = (await request.json()) as { content?: string; tts?: boolean };
+    const body = (await request.json()) as { content?: string; tts?: boolean; flags?: number; components?: unknown[] };
     return HttpResponse.json({
       id: '999000999000999000',
-      channel_id: params.channelId,
+      channel_id: params['channelId'],
       content: body.content ?? '',
       tts: body.tts ?? false,
       timestamp: '2026-04-28T12:00:00.000000+00:00',
       author: { id: '111', username: 'TestBot', global_name: 'TestBot', bot: true },
       type: 0,
+      ...(body.flags !== undefined && { flags: body.flags }),
+      ...(body.components !== undefined && { components: body.components }),
     });
   }),
   // messages_read
@@ -214,12 +216,14 @@ export const handlers = [
   http.patch(
     `${DISCORD_API}/channels/:channelId/messages/:messageId`,
     async ({ params, request }) => {
-      const body = (await request.json()) as { content?: string };
+      const body = (await request.json()) as { content?: string; flags?: number; components?: unknown[] };
       return HttpResponse.json({
         id: params['messageId'],
         channel_id: params['channelId'],
         content: body.content ?? '',
         edited_timestamp: '2026-04-28T13:00:00.000000+00:00',
+        ...(body.flags !== undefined && { flags: body.flags }),
+        ...(body.components !== undefined && { components: body.components }),
       });
     },
   ),


### PR DESCRIPTION
## Summary

- **8 new tools** in `components_v2_*` category — send, edit, validate (offline), preview (ASCII), send_from_template, build_container, build_section, build_media_gallery.
- **Discriminated-union schema** covering 14 component types (ActionRow, Button, 5 Selects, Section, TextDisplay, Thumbnail, MediaGallery, File, Separator, Container).
- **Offline validator** catching 40-cap, nesting violations (Container-in-Container, Thumbnail-standalone), accessory mismatches, MediaGallery range, ActionRow size cap, Button missing custom_id/url. Saves Discord round-trips.
- **ASCII preview** renderer for iterating layouts without sending — pairs with validator.
- **5 ship-with templates** (announcement, release_notes, welcome_card, poll_results, incident_status) exposed as MCP resources at `discord://components-v2/templates/<name>`.
- **MCP resources/list + resources/read** handlers in server.ts; schema served at `discord://components-v2/schema` (zod → JSON Schema draft-2020-12).
- **IS_COMPONENTS_V2 flag** (`1<<15`) on send + edit; mutex with content/embed/poll/sticker enforced offline.

## Stats

- 23 tools total (15 prior + 8 V2)
- 6 MCP resources (5 templates + 1 schema)
- 175 tests passing
- Tag: `v0.3.0`

## Test Plan

- [x] `pnpm lint && pnpm typecheck && pnpm build && pnpm test` all green
- [x] Smoke test: 23 tools advertised via `tools/list`
- [x] Smoke test: `resources/list` returns 6
- [ ] CI green on this PR (Node 22.12 + 24.x + audit)

## What's deferred

- Pipeline executor → Plan 4
- Intelligence sampling tools → Plan 5
- Full Sapphire ResourceStore + Discord Gateway resource subscriptions → Plan 6
- Remaining 130+ tools batched by category → Plan 7
- Telemetry / audit / redact / cockatiel resilience middlewares → Plan 8
- CLI sub-commands (`doctor`, `init`, `migrate`) → Plan 9
- MCP Apps iframe builder → v1.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)