### PR TITLE
Plan 4: mcp_pipeline executor (USP)

### DIFF
--- a/packages/mcp-core/src/errors/format.test.ts
+++ b/packages/mcp-core/src/errors/format.test.ts
@@ -12,7 +12,7 @@ import {
   ScopeRejectedError,
   ValidationError,
 } from './index.js';
-import { DiscordServerErrorImpl, InternalError } from './server.js';
+import { DiscordServerErrorImpl } from './server.js';
 
 const stdio = { toolName: 'messages_send', transport: 'stdio' as const };
 

--- a/packages/mcp-core/src/errors/format.ts
+++ b/packages/mcp-core/src/errors/format.ts
@@ -37,7 +37,7 @@ function makeError(opts: MakeErrorOpts): CallToolResult {
     ...opts.structured,
   };
   if (opts.retry_after_ms !== undefined) {
-    structured['retry_after_ms'] = opts.retry_after_ms;
+    structured.retry_after_ms = opts.retry_after_ms;
   }
   return {
     isError: true,
@@ -75,7 +75,7 @@ export function formatErrorForUser(e: unknown, ctx: FormatErrorContext): CallToo
       scope: e.scope,
     };
     if (e.suggestedTool !== undefined) {
-      structured['suggested_tool'] = e.suggestedTool;
+      structured.suggested_tool = e.suggestedTool;
     }
     return makeError({
       code: e.code,
@@ -98,7 +98,7 @@ export function formatErrorForUser(e: unknown, ctx: FormatErrorContext): CallToo
       id: e.id,
     };
     if (e.suggestedTool !== undefined) {
-      structured['suggested_tool'] = e.suggestedTool;
+      structured.suggested_tool = e.suggestedTool;
     }
     return makeError({
       code: e.code,
@@ -204,7 +204,7 @@ export function formatErrorForUser(e: unknown, ctx: FormatErrorContext): CallToo
   if (e instanceof DiscordServerError) {
     const structured: Record<string, unknown> = {};
     if (ctx.sentryEventId !== undefined) {
-      structured['trace_id'] = ctx.sentryEventId;
+      structured.trace_id = ctx.sentryEventId;
     }
     return makeError({
       code: e.code,
@@ -233,7 +233,7 @@ export function formatErrorForUser(e: unknown, ctx: FormatErrorContext): CallToo
 
   const structured: Record<string, unknown> = {};
   if (ctx.sentryEventId !== undefined) {
-    structured['trace_id'] = ctx.sentryEventId;
+    structured.trace_id = ctx.sentryEventId;
   }
   return makeError({
     code: 'INTERNAL_ERROR',

--- a/packages/mcp-core/src/index.ts
+++ b/packages/mcp-core/src/index.ts
@@ -38,6 +38,16 @@ export { validateMiddleware } from './middleware/validate.js';
 export { Precondition } from './pieces/Precondition.js';
 // Pieces
 export { Tool, type ToolAnnotations, type ToolRunContext } from './pieces/Tool.js';
+// Pipeline
+export {
+  executePipeline,
+  type InvokeFn,
+  type PipelineExecutorCtx,
+  type PipelineResult,
+  type Step,
+  type StepResult,
+} from './pipeline/executor.js';
+export { evalCondition, interpolate, resolvePath } from './pipeline/interpolate.js';
 // Preconditions
 export { CategoryEnabled } from './preconditions/CategoryEnabled.js';
 export { ConfirmRequired } from './preconditions/ConfirmRequired.js';

--- a/packages/mcp-core/src/pipeline/executor.test.ts
+++ b/packages/mcp-core/src/pipeline/executor.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
-import { executePipeline, type Step, type PipelineExecutorCtx } from './executor.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it, vi } from 'vitest';
+import { executePipeline, type PipelineExecutorCtx } from './executor.js';
 
 const ok = (data: Record<string, unknown>): CallToolResult => ({
   isError: false,
@@ -28,18 +28,27 @@ describe('executePipeline', () => {
     expect(result.steps).toHaveLength(1);
     expect(result.steps[0]!.status).toBe('success');
     expect(result.steps[0]!.id).toBe('send');
-    expect(result.variables['send']).toEqual({ message_id: 'm1' });
-    expect(invoke).toHaveBeenCalledWith('messages_send', { channel_id: 'c1', content: 'hi' }, baseCtx.signal);
+    expect(result.variables.send).toEqual({ message_id: 'm1' });
+    expect(invoke).toHaveBeenCalledWith(
+      'messages_send',
+      { channel_id: 'c1', content: 'hi' },
+      baseCtx.signal,
+    );
   });
 
   it('interpolates variables from earlier steps into later step args', async () => {
-    const invoke = vi.fn()
+    const invoke = vi
+      .fn()
       .mockResolvedValueOnce(ok({ messages: [{ id: 'msg_1' }] }))
       .mockResolvedValueOnce(ok({ deleted: true, message_id: 'msg_1' }));
     const result = await executePipeline(
       [
         { id: 'read', tool: 'messages_read', args: { channel_id: 'c1' } },
-        { id: 'del', tool: 'messages_delete', args: { channel_id: 'c1', message_id: '{{read.messages[0].id}}' } },
+        {
+          id: 'del',
+          tool: 'messages_delete',
+          args: { channel_id: 'c1', message_id: '{{read.messages[0].id}}' },
+        },
       ],
       invoke,
       baseCtx,
@@ -55,18 +64,24 @@ describe('executePipeline', () => {
       invoke,
       baseCtx,
     );
-    expect(result.variables['count']).toEqual({ count: 7 });
-    expect(result.variables['channels']).toEqual({ count: 7 });
+    expect(result.variables.count).toEqual({ count: 7 });
+    expect(result.variables.channels).toEqual({ count: 7 });
   });
 
   it('skips a step whose `if` resolves falsy', async () => {
-    const invoke = vi.fn()
+    const invoke = vi
+      .fn()
       .mockResolvedValueOnce(ok({ count: 0 }))
       .mockResolvedValueOnce(ok({ message_id: 'm2' }));
     const result = await executePipeline(
       [
         { id: 'first', tool: 'channels_list', args: { guild_id: 'g1' } },
-        { id: 'maybe', tool: 'messages_send', args: { channel_id: 'c1', content: 'hi' }, if: '{{first.count}}' },
+        {
+          id: 'maybe',
+          tool: 'messages_send',
+          args: { channel_id: 'c1', content: 'hi' },
+          if: '{{first.count}}',
+        },
       ],
       invoke,
       baseCtx,
@@ -76,7 +91,8 @@ describe('executePipeline', () => {
   });
 
   it('aborts the pipeline when a step fails (default continue_on_error: false)', async () => {
-    const invoke = vi.fn()
+    const invoke = vi
+      .fn()
       .mockResolvedValueOnce(ok({ messages: [] }))
       .mockResolvedValueOnce(err('DISCORD_PERMISSION_DENIED', 'no perm'))
       .mockResolvedValueOnce(ok({ never: 'reached' }));
@@ -97,7 +113,8 @@ describe('executePipeline', () => {
   });
 
   it('continues past a failed step when continue_on_error is true', async () => {
-    const invoke = vi.fn()
+    const invoke = vi
+      .fn()
       .mockResolvedValueOnce(err('DISCORD_NOT_FOUND', 'gone'))
       .mockResolvedValueOnce(ok({ ok: true }));
     const result = await executePipeline(
@@ -125,27 +142,19 @@ describe('executePipeline', () => {
     );
     expect(result.steps[0]!.id).toBe('step_0');
     expect(result.steps[1]!.id).toBe('step_1');
-    expect(result.variables['step_0']).toEqual({ ok: true });
+    expect(result.variables.step_0).toEqual({ ok: true });
   });
 
   it('records duration_ms per step (>= 0)', async () => {
     const invoke = vi.fn().mockResolvedValue(ok({}));
-    const result = await executePipeline(
-      [{ id: 'a', tool: 'x', args: {} }],
-      invoke,
-      baseCtx,
-    );
+    const result = await executePipeline([{ id: 'a', tool: 'x', args: {} }], invoke, baseCtx);
     expect(result.steps[0]!.duration_ms).toBeGreaterThanOrEqual(0);
     expect(typeof result.total_duration_ms).toBe('number');
   });
 
   it('captures error code + retriable from a failed CallToolResult', async () => {
     const invoke = vi.fn().mockResolvedValue(err('DISCORD_RATE_LIMITED', 'wait'));
-    const result = await executePipeline(
-      [{ id: 'a', tool: 'x', args: {} }],
-      invoke,
-      baseCtx,
-    );
+    const result = await executePipeline([{ id: 'a', tool: 'x', args: {} }], invoke, baseCtx);
     expect(result.steps[0]!.error?.code).toBe('DISCORD_RATE_LIMITED');
     expect(result.steps[0]!.error?.retriable).toBe(false);
   });
@@ -154,11 +163,9 @@ describe('executePipeline', () => {
     const ac = new AbortController();
     ac.abort();
     const invoke = vi.fn();
-    const result = await executePipeline(
-      [{ id: 'a', tool: 'x', args: {} }],
-      invoke,
-      { signal: ac.signal },
-    );
+    const result = await executePipeline([{ id: 'a', tool: 'x', args: {} }], invoke, {
+      signal: ac.signal,
+    });
     expect(result.aborted).toBe(true);
     expect(result.steps).toHaveLength(0);
     expect(invoke).not.toHaveBeenCalled();

--- a/packages/mcp-core/src/pipeline/executor.test.ts
+++ b/packages/mcp-core/src/pipeline/executor.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from 'vitest';
+import { executePipeline, type Step, type PipelineExecutorCtx } from './executor.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+const ok = (data: Record<string, unknown>): CallToolResult => ({
+  isError: false,
+  content: [{ type: 'text', text: 'ok' }],
+  structuredContent: data,
+});
+
+const err = (code: string, message: string): CallToolResult => ({
+  isError: true,
+  content: [{ type: 'text', text: message }],
+  structuredContent: { code, retriable: false, category: 'client' },
+});
+
+describe('executePipeline', () => {
+  const baseCtx: PipelineExecutorCtx = { signal: new AbortController().signal };
+
+  it('runs a single step and captures result under step id', async () => {
+    const invoke = vi.fn().mockResolvedValue(ok({ message_id: 'm1' }));
+    const result = await executePipeline(
+      [{ id: 'send', tool: 'messages_send', args: { channel_id: 'c1', content: 'hi' } }],
+      invoke,
+      baseCtx,
+    );
+    expect(result.aborted).toBe(false);
+    expect(result.steps).toHaveLength(1);
+    expect(result.steps[0]!.status).toBe('success');
+    expect(result.steps[0]!.id).toBe('send');
+    expect(result.variables['send']).toEqual({ message_id: 'm1' });
+    expect(invoke).toHaveBeenCalledWith('messages_send', { channel_id: 'c1', content: 'hi' }, baseCtx.signal);
+  });
+
+  it('interpolates variables from earlier steps into later step args', async () => {
+    const invoke = vi.fn()
+      .mockResolvedValueOnce(ok({ messages: [{ id: 'msg_1' }] }))
+      .mockResolvedValueOnce(ok({ deleted: true, message_id: 'msg_1' }));
+    const result = await executePipeline(
+      [
+        { id: 'read', tool: 'messages_read', args: { channel_id: 'c1' } },
+        { id: 'del', tool: 'messages_delete', args: { channel_id: 'c1', message_id: '{{read.messages[0].id}}' } },
+      ],
+      invoke,
+      baseCtx,
+    );
+    expect(result.aborted).toBe(false);
+    expect(invoke.mock.calls[1]![1]).toEqual({ channel_id: 'c1', message_id: 'msg_1' });
+  });
+
+  it('save_as aliases the result under both step id and the alias', async () => {
+    const invoke = vi.fn().mockResolvedValue(ok({ count: 7 }));
+    const result = await executePipeline(
+      [{ id: 'count', tool: 'channels_list', args: { guild_id: 'g1' }, save_as: 'channels' }],
+      invoke,
+      baseCtx,
+    );
+    expect(result.variables['count']).toEqual({ count: 7 });
+    expect(result.variables['channels']).toEqual({ count: 7 });
+  });
+
+  it('skips a step whose `if` resolves falsy', async () => {
+    const invoke = vi.fn()
+      .mockResolvedValueOnce(ok({ count: 0 }))
+      .mockResolvedValueOnce(ok({ message_id: 'm2' }));
+    const result = await executePipeline(
+      [
+        { id: 'first', tool: 'channels_list', args: { guild_id: 'g1' } },
+        { id: 'maybe', tool: 'messages_send', args: { channel_id: 'c1', content: 'hi' }, if: '{{first.count}}' },
+      ],
+      invoke,
+      baseCtx,
+    );
+    expect(result.steps[1]!.status).toBe('skipped');
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the pipeline when a step fails (default continue_on_error: false)', async () => {
+    const invoke = vi.fn()
+      .mockResolvedValueOnce(ok({ messages: [] }))
+      .mockResolvedValueOnce(err('DISCORD_PERMISSION_DENIED', 'no perm'))
+      .mockResolvedValueOnce(ok({ never: 'reached' }));
+    const result = await executePipeline(
+      [
+        { id: 'a', tool: 'messages_read', args: {} },
+        { id: 'b', tool: 'messages_send', args: { content: 'x' } },
+        { id: 'c', tool: 'messages_send', args: { content: 'y' } },
+      ],
+      invoke,
+      baseCtx,
+    );
+    expect(result.aborted).toBe(true);
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0]!.status).toBe('success');
+    expect(result.steps[1]!.status).toBe('error');
+    expect(invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it('continues past a failed step when continue_on_error is true', async () => {
+    const invoke = vi.fn()
+      .mockResolvedValueOnce(err('DISCORD_NOT_FOUND', 'gone'))
+      .mockResolvedValueOnce(ok({ ok: true }));
+    const result = await executePipeline(
+      [
+        { id: 'a', tool: 'messages_delete', args: {}, continue_on_error: true },
+        { id: 'b', tool: 'messages_send', args: {} },
+      ],
+      invoke,
+      baseCtx,
+    );
+    expect(result.aborted).toBe(false);
+    expect(result.steps[0]!.status).toBe('error');
+    expect(result.steps[1]!.status).toBe('success');
+  });
+
+  it('default-ids unnamed steps as step_<index>', async () => {
+    const invoke = vi.fn().mockResolvedValue(ok({ ok: true }));
+    const result = await executePipeline(
+      [
+        { tool: 'messages_send', args: { content: 'a' } },
+        { tool: 'messages_send', args: { content: 'b' } },
+      ],
+      invoke,
+      baseCtx,
+    );
+    expect(result.steps[0]!.id).toBe('step_0');
+    expect(result.steps[1]!.id).toBe('step_1');
+    expect(result.variables['step_0']).toEqual({ ok: true });
+  });
+
+  it('records duration_ms per step (>= 0)', async () => {
+    const invoke = vi.fn().mockResolvedValue(ok({}));
+    const result = await executePipeline(
+      [{ id: 'a', tool: 'x', args: {} }],
+      invoke,
+      baseCtx,
+    );
+    expect(result.steps[0]!.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(typeof result.total_duration_ms).toBe('number');
+  });
+
+  it('captures error code + retriable from a failed CallToolResult', async () => {
+    const invoke = vi.fn().mockResolvedValue(err('DISCORD_RATE_LIMITED', 'wait'));
+    const result = await executePipeline(
+      [{ id: 'a', tool: 'x', args: {} }],
+      invoke,
+      baseCtx,
+    );
+    expect(result.steps[0]!.error?.code).toBe('DISCORD_RATE_LIMITED');
+    expect(result.steps[0]!.error?.retriable).toBe(false);
+  });
+
+  it('aborts pipeline if signal is already aborted', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const invoke = vi.fn();
+    const result = await executePipeline(
+      [{ id: 'a', tool: 'x', args: {} }],
+      invoke,
+      { signal: ac.signal },
+    );
+    expect(result.aborted).toBe(true);
+    expect(result.steps).toHaveLength(0);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-core/src/pipeline/executor.ts
+++ b/packages/mcp-core/src/pipeline/executor.ts
@@ -1,5 +1,5 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { interpolate, evalCondition } from './interpolate.js';
+import { evalCondition, interpolate } from './interpolate.js';
 
 export interface Step {
   readonly id?: string;

--- a/packages/mcp-core/src/pipeline/executor.ts
+++ b/packages/mcp-core/src/pipeline/executor.ts
@@ -1,0 +1,123 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { interpolate, evalCondition } from './interpolate.js';
+
+export interface Step {
+  readonly id?: string;
+  readonly tool: string;
+  readonly args: Record<string, unknown>;
+  readonly save_as?: string;
+  readonly if?: string;
+  readonly continue_on_error?: boolean;
+}
+
+export interface StepResult {
+  readonly id: string;
+  readonly tool: string;
+  readonly status: 'success' | 'error' | 'skipped';
+  readonly result?: unknown;
+  readonly error?: { code: string; message: string; retriable: boolean };
+  readonly duration_ms: number;
+}
+
+export interface PipelineResult {
+  readonly steps: readonly StepResult[];
+  readonly variables: Readonly<Record<string, unknown>>;
+  readonly total_duration_ms: number;
+  readonly aborted: boolean;
+}
+
+export interface PipelineExecutorCtx {
+  readonly signal: AbortSignal;
+}
+
+export type InvokeFn = (
+  toolName: string,
+  args: unknown,
+  signal: AbortSignal,
+) => Promise<CallToolResult>;
+
+interface ErrorPayload {
+  code?: string;
+  retriable?: boolean;
+}
+
+export async function executePipeline(
+  steps: readonly Step[],
+  invoke: InvokeFn,
+  ctx: PipelineExecutorCtx,
+): Promise<PipelineResult> {
+  const variables: Record<string, unknown> = {};
+  const results: StepResult[] = [];
+  const totalStart = performance.now();
+  let aborted = ctx.signal.aborted;
+
+  for (let i = 0; i < steps.length && !aborted; i++) {
+    const step = steps[i]!;
+    const id = step.id ?? `step_${i}`;
+
+    if (step.if !== undefined) {
+      if (!evalCondition(step.if, variables)) {
+        results.push({ id, tool: step.tool, status: 'skipped', duration_ms: 0 });
+        continue;
+      }
+    }
+
+    const interpolatedArgs = interpolate(step.args, variables) as Record<string, unknown>;
+    const stepStart = performance.now();
+    let stepResult: StepResult;
+    try {
+      const callResult = await invoke(step.tool, interpolatedArgs, ctx.signal);
+      const duration = performance.now() - stepStart;
+      if (callResult.isError === true) {
+        const payload = (callResult.structuredContent ?? {}) as ErrorPayload;
+        const text = (callResult.content as Array<{ text?: string }> | undefined)?.[0]?.text ?? '';
+        stepResult = {
+          id,
+          tool: step.tool,
+          status: 'error',
+          error: {
+            code: payload.code ?? 'UNKNOWN',
+            message: text,
+            retriable: payload.retriable === true,
+          },
+          duration_ms: duration,
+        };
+      } else {
+        const data = callResult.structuredContent;
+        variables[id] = data;
+        if (step.save_as !== undefined) variables[step.save_as] = data;
+        stepResult = {
+          id,
+          tool: step.tool,
+          status: 'success',
+          result: data,
+          duration_ms: duration,
+        };
+      }
+    } catch (e) {
+      const duration = performance.now() - stepStart;
+      const message = e instanceof Error ? e.message : String(e);
+      stepResult = {
+        id,
+        tool: step.tool,
+        status: 'error',
+        error: { code: 'PIPELINE_INTERNAL', message, retriable: false },
+        duration_ms: duration,
+      };
+    }
+
+    results.push(stepResult);
+
+    if (stepResult.status === 'error' && step.continue_on_error !== true) {
+      aborted = true;
+      break;
+    }
+  }
+
+  return {
+    steps: results,
+    variables,
+    total_duration_ms: performance.now() - totalStart,
+    aborted,
+  };
+}

--- a/packages/mcp-core/src/pipeline/interpolate.test.ts
+++ b/packages/mcp-core/src/pipeline/interpolate.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { interpolate, resolvePath, evalCondition } from './interpolate.js';
+
+describe('resolvePath', () => {
+  const vars = {
+    step1: { id: 'msg_123', author: { name: 'alice' }, items: ['a', 'b', 'c'] },
+    counter: 5,
+  };
+
+  it('resolves a simple key', () => {
+    expect(resolvePath('counter', vars)).toBe(5);
+  });
+
+  it('resolves a nested object path with dots', () => {
+    expect(resolvePath('step1.id', vars)).toBe('msg_123');
+    expect(resolvePath('step1.author.name', vars)).toBe('alice');
+  });
+
+  it('resolves an array index with bracket notation', () => {
+    expect(resolvePath('step1.items[0]', vars)).toBe('a');
+    expect(resolvePath('step1.items[2]', vars)).toBe('c');
+  });
+
+  it('returns undefined for a missing path', () => {
+    expect(resolvePath('step1.missing', vars)).toBeUndefined();
+    expect(resolvePath('absent.path', vars)).toBeUndefined();
+  });
+
+  it('returns undefined for a path that goes through null/undefined', () => {
+    expect(resolvePath('step1.author.deep.deeper', vars)).toBeUndefined();
+  });
+});
+
+describe('interpolate', () => {
+  const vars = {
+    step1: { id: 'msg_123', count: 5 },
+    step2: { url: 'https://example.com' },
+  };
+
+  it('returns raw value (type-preserved) when entire string is a single template', () => {
+    expect(interpolate('{{step1.id}}', vars)).toBe('msg_123');
+    expect(interpolate('{{step1.count}}', vars)).toBe(5);
+  });
+
+  it('stringifies and concatenates multi-template strings', () => {
+    expect(interpolate('count is {{step1.count}}', vars)).toBe('count is 5');
+    expect(interpolate('{{step1.id}} at {{step2.url}}', vars)).toBe('msg_123 at https://example.com');
+  });
+
+  it('leaves missing variables as the literal placeholder in mixed strings', () => {
+    expect(interpolate('hello {{absent.var}}', vars)).toBe('hello {{absent.var}}');
+  });
+
+  it('returns undefined when a single-template references a missing path', () => {
+    expect(interpolate('{{absent.var}}', vars)).toBeUndefined();
+  });
+
+  it('recurses into objects', () => {
+    const out = interpolate({ a: '{{step1.id}}', b: 'plain' }, vars);
+    expect(out).toEqual({ a: 'msg_123', b: 'plain' });
+  });
+
+  it('recurses into arrays', () => {
+    const out = interpolate(['{{step1.id}}', 'plain', '{{step2.url}}'], vars);
+    expect(out).toEqual(['msg_123', 'plain', 'https://example.com']);
+  });
+
+  it('does not interpolate non-string primitives', () => {
+    expect(interpolate({ n: 42, b: true, nul: null }, vars)).toEqual({ n: 42, b: true, nul: null });
+  });
+});
+
+describe('evalCondition', () => {
+  const vars = {
+    step1: { has_items: true, count: 0, name: '' },
+    step2: { count: 5 },
+  };
+
+  it('returns true for a truthy path', () => {
+    expect(evalCondition('{{step1.has_items}}', vars)).toBe(true);
+    expect(evalCondition('{{step2.count}}', vars)).toBe(true);
+  });
+
+  it('returns false for a falsy path', () => {
+    expect(evalCondition('{{step1.count}}', vars)).toBe(false);
+    expect(evalCondition('{{step1.name}}', vars)).toBe(false);
+    expect(evalCondition('{{absent.path}}', vars)).toBe(false);
+  });
+
+  it('strips outer {{ }} if present', () => {
+    expect(evalCondition('step1.has_items', vars)).toBe(true);
+  });
+});

--- a/packages/mcp-core/src/pipeline/interpolate.test.ts
+++ b/packages/mcp-core/src/pipeline/interpolate.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { interpolate, resolvePath, evalCondition } from './interpolate.js';
+import { describe, expect, it } from 'vitest';
+import { evalCondition, interpolate, resolvePath } from './interpolate.js';
 
 describe('resolvePath', () => {
   const vars = {
@@ -44,7 +44,9 @@ describe('interpolate', () => {
 
   it('stringifies and concatenates multi-template strings', () => {
     expect(interpolate('count is {{step1.count}}', vars)).toBe('count is 5');
-    expect(interpolate('{{step1.id}} at {{step2.url}}', vars)).toBe('msg_123 at https://example.com');
+    expect(interpolate('{{step1.id}} at {{step2.url}}', vars)).toBe(
+      'msg_123 at https://example.com',
+    );
   });
 
   it('leaves missing variables as the literal placeholder in mixed strings', () => {

--- a/packages/mcp-core/src/pipeline/interpolate.ts
+++ b/packages/mcp-core/src/pipeline/interpolate.ts
@@ -1,0 +1,50 @@
+const TEMPLATE_RE = /\{\{([^}]+)\}\}/g;
+const SINGLE_TEMPLATE_RE = /^\{\{([^}]+)\}\}$/;
+
+export function resolvePath(path: string, vars: Record<string, unknown>): unknown {
+  const segments = path
+    .replace(/\[(\d+)\]/g, '.$1')
+    .split('.')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  let cur: unknown = vars;
+  for (const seg of segments) {
+    if (cur === null || cur === undefined) return undefined;
+    if (typeof cur !== 'object') return undefined;
+    cur = (cur as Record<string, unknown>)[seg];
+  }
+  return cur;
+}
+
+export function interpolate<T>(value: T, vars: Record<string, unknown>): T {
+  if (typeof value === 'string') {
+    const single = value.match(SINGLE_TEMPLATE_RE);
+    if (single !== null) {
+      const path = single[1]!.trim();
+      return resolvePath(path, vars) as never as T;
+    }
+    return value.replace(TEMPLATE_RE, (full, path: string) => {
+      const resolved = resolvePath(path.trim(), vars);
+      return resolved === undefined ? full : String(resolved);
+    }) as never as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => interpolate(v, vars)) as never as T;
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = interpolate(v, vars);
+    }
+    return out as T;
+  }
+  return value;
+}
+
+export function evalCondition(expr: string, vars: Record<string, unknown>): boolean {
+  const trimmed = expr.trim();
+  const single = trimmed.match(SINGLE_TEMPLATE_RE);
+  const path = single !== null ? single[1]!.trim() : trimmed;
+  const value = resolvePath(path, vars);
+  return Boolean(value);
+}

--- a/packages/mcp-core/src/preconditions/CategoryEnabled.ts
+++ b/packages/mcp-core/src/preconditions/CategoryEnabled.ts
@@ -16,7 +16,7 @@ export class CategoryEnabled extends Precondition {
   }
 
   public override async run(ctx: MiddlewareContext<unknown>): Promise<void> {
-    const raw = this.env['MCP_CATEGORIES'];
+    const raw = this.env.MCP_CATEGORIES;
     if (raw === undefined || raw.trim() === '') {
       return;
     }

--- a/packages/mcp-core/src/preconditions/ConfirmRequired.ts
+++ b/packages/mcp-core/src/preconditions/ConfirmRequired.ts
@@ -16,9 +16,9 @@ export class ConfirmRequired extends Precondition {
   }
 
   public override async run(ctx: MiddlewareContext<unknown>): Promise<void> {
-    const dryRunActive = this.env['MCP_DRY_RUN'] !== 'false';
+    const dryRunActive = this.env.MCP_DRY_RUN !== 'false';
     const args = ctx.args as Record<string, unknown>;
-    const confirmed = args['__confirm'] === true;
+    const confirmed = args.__confirm === true;
 
     if (dryRunActive || !confirmed) {
       const preview: Record<string, unknown> = {};

--- a/packages/mcp-core/src/server.contract.test.ts
+++ b/packages/mcp-core/src/server.contract.test.ts
@@ -81,9 +81,9 @@ describe('MCP protocol contract', () => {
     expect(text).toMatch(/channel_id/);
   });
 
-  it('lists 23 tools after auto-discovery (Plan 0+1+2+3D+3E+3F cumulative)', async () => {
+  it('lists 24 tools after auto-discovery (Plan 0+1+2+3+4 cumulative)', async () => {
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(23);
+    expect(tools.length).toBe(24);
     const names = new Set(tools.map((t) => t.name));
     for (const expected of [
       'messages_send',
@@ -109,9 +109,44 @@ describe('MCP protocol contract', () => {
       'components_v2_send',
       'components_v2_edit',
       'components_v2_send_from_template',
+      'mcp_pipeline',
     ]) {
       expect(names.has(expected)).toBe(true);
     }
+  });
+
+  it('mcp_pipeline executes a 2-step pipeline end-to-end', async () => {
+    const r = await client.callTool({
+      name: 'mcp_pipeline',
+      arguments: {
+        steps: [
+          { id: 'step1', tool: 'channels_list', args: { guild_id: '999000999000999000' } },
+          { id: 'step2', tool: 'messages_send', args: { channel_id: '{{step1.channels[0].id}}', content: 'pipeline ran' } },
+        ],
+      },
+    });
+    expect(r.isError).toBe(false);
+    expect(r.structuredContent).toMatchObject({
+      aborted: false,
+      steps: expect.arrayContaining([
+        expect.objectContaining({ id: 'step1', status: 'success' }),
+        expect.objectContaining({ id: 'step2', status: 'success' }),
+      ]),
+    });
+  });
+
+  it('mcp_pipeline rejects nested pipeline calls', async () => {
+    const r = await client.callTool({
+      name: 'mcp_pipeline',
+      arguments: { steps: [{ id: 'inner', tool: 'mcp_pipeline', args: { steps: [] } }] },
+    });
+    expect(r.isError).toBe(false);
+    expect(r.structuredContent).toMatchObject({
+      aborted: true,
+      steps: expect.arrayContaining([
+        expect.objectContaining({ status: 'error', error: expect.objectContaining({ code: 'PIPELINE_RECURSION' }) }),
+      ]),
+    });
   });
 
   it('messages_delete returns DRY_RUN_PREVIEW without __confirm', async () => {

--- a/packages/mcp-core/src/server.contract.test.ts
+++ b/packages/mcp-core/src/server.contract.test.ts
@@ -121,7 +121,11 @@ describe('MCP protocol contract', () => {
       arguments: {
         steps: [
           { id: 'step1', tool: 'channels_list', args: { guild_id: '999000999000999000' } },
-          { id: 'step2', tool: 'messages_send', args: { channel_id: '{{step1.channels[0].id}}', content: 'pipeline ran' } },
+          {
+            id: 'step2',
+            tool: 'messages_send',
+            args: { channel_id: '{{step1.channels[0].id}}', content: 'pipeline ran' },
+          },
         ],
       },
     });
@@ -144,7 +148,10 @@ describe('MCP protocol contract', () => {
     expect(r.structuredContent).toMatchObject({
       aborted: true,
       steps: expect.arrayContaining([
-        expect.objectContaining({ status: 'error', error: expect.objectContaining({ code: 'PIPELINE_RECURSION' }) }),
+        expect.objectContaining({
+          status: 'error',
+          error: expect.objectContaining({ code: 'PIPELINE_RECURSION' }),
+        }),
       ]),
     });
   });

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -6,6 +6,7 @@ import {
   ListResourcesRequestSchema,
   ListToolsRequestSchema,
   type Tool as McpTool,
+  type CallToolResult,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { container } from '@sapphire/pieces';
@@ -23,6 +24,7 @@ import { ConfirmRequired } from './preconditions/ConfirmRequired.js';
 import { listV2Resources, readV2Resource } from './resources/components-v2.js';
 import { PreconditionStore } from './stores/PreconditionStore.js';
 import { ToolStore } from './stores/ToolStore.js';
+import McpPipeline from './tools/meta/pipeline.js';
 import AuditLogGet from './tools/audit_log/get.js';
 import ChannelsGet from './tools/channels/get.js';
 import ChannelsList from './tools/channels/list.js';
@@ -150,6 +152,10 @@ export async function buildServer(deps: BuildServerDeps): Promise<BuildServerRes
     name: 'components_v2_send_from_template',
     piece: ComponentsV2SendFromTemplate as unknown as ConcreteTool,
   });
+  await toolStore.loadPiece({
+    name: 'mcp_pipeline',
+    piece: McpPipeline as unknown as ConcreteTool,
+  });
   await toolStore.loadAll();
 
   preconditionStore.set(
@@ -204,42 +210,48 @@ export async function buildServer(deps: BuildServerDeps): Promise<BuildServerRes
     return { tools };
   });
 
-  server.setRequestHandler(CallToolRequestSchema, async (req, extra) => {
-    const tool = toolStore.get(req.params.name);
+  const invokeTool = async (
+    toolName: string,
+    args: unknown,
+    signal: AbortSignal,
+  ): Promise<CallToolResult> => {
+    const tool = toolStore.get(toolName);
     if (tool === undefined) {
-      return formatErrorForUser(new Error(`Tool '${req.params.name}' not found.`), {
-        toolName: req.params.name,
+      return formatErrorForUser(new Error(`Tool '${toolName}' not found.`), {
+        toolName,
         transport: 'stdio',
       });
     }
-
-    const requestId = randomUUID();
-    const requestCtx = {
-      requestId,
-      toolName: tool.name,
-      transport: 'stdio' as const,
-      signal: extra.signal,
-    };
-
     const middlewareCtx: MiddlewareContext<unknown> = {
       tool: { name: tool.name, category: tool.category, idempotent: tool.idempotent },
-      args: req.params.arguments ?? {},
+      args: args ?? {},
       meta: new Map<string, unknown>([
         ['toolPiece', tool],
         ['toolPreconditions', tool.preconditions],
       ]),
     };
-
     const dispatch = compose(middlewares, async (c) => {
-      return tool.run(c.args, { signal: extra.signal });
+      return tool.run(c.args, { signal, invoke: invokeTool } as never);
     });
-
     try {
-      return (await runWithCtx(requestCtx, async () => dispatch(middlewareCtx))) as never;
+      return (await dispatch(middlewareCtx)) as CallToolResult;
     } catch (e) {
-      deps.logger.warn({ err: e, tool: tool.name, requestId }, 'tool error');
+      deps.logger.warn({ err: e, tool: tool.name }, 'tool error');
       return formatErrorForUser(e, { toolName: tool.name, transport: 'stdio' });
     }
+  };
+
+  server.setRequestHandler(CallToolRequestSchema, async (req, extra) => {
+    const requestId = randomUUID();
+    const requestCtx = {
+      requestId,
+      toolName: req.params.name,
+      transport: 'stdio' as const,
+      signal: extra.signal,
+    };
+    return runWithCtx(requestCtx, async () =>
+      invokeTool(req.params.name, req.params.arguments, extra.signal),
+    );
   });
 
   server.setRequestHandler(ListResourcesRequestSchema, async () => {

--- a/packages/mcp-core/src/server.ts
+++ b/packages/mcp-core/src/server.ts
@@ -3,10 +3,10 @@ import type { REST } from '@discordjs/rest';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   CallToolRequestSchema,
+  type CallToolResult,
   ListResourcesRequestSchema,
   ListToolsRequestSchema,
   type Tool as McpTool,
-  type CallToolResult,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { container } from '@sapphire/pieces';
@@ -24,7 +24,6 @@ import { ConfirmRequired } from './preconditions/ConfirmRequired.js';
 import { listV2Resources, readV2Resource } from './resources/components-v2.js';
 import { PreconditionStore } from './stores/PreconditionStore.js';
 import { ToolStore } from './stores/ToolStore.js';
-import McpPipeline from './tools/meta/pipeline.js';
 import AuditLogGet from './tools/audit_log/get.js';
 import ChannelsGet from './tools/channels/get.js';
 import ChannelsList from './tools/channels/list.js';
@@ -45,6 +44,7 @@ import MessagesDelete from './tools/messages/delete.js';
 import MessagesEdit from './tools/messages/edit.js';
 import MessagesRead from './tools/messages/read.js';
 import MessagesSend from './tools/messages/send.js';
+import McpPipeline from './tools/meta/pipeline.js';
 import RolesList from './tools/roles/list.js';
 import UsersGetCurrent from './tools/users/get_current.js';
 import WebhooksListChannel from './tools/webhooks/list_channel.js';

--- a/packages/mcp-core/src/tools/_lib/pagination.ts
+++ b/packages/mcp-core/src/tools/_lib/pagination.ts
@@ -18,7 +18,7 @@ export function decodeCursor(s: string): CursorPayload {
     if (
       typeof parsed !== 'object' ||
       parsed === null ||
-      typeof (parsed as Record<string, unknown>)['limit'] !== 'number'
+      typeof (parsed as Record<string, unknown>).limit !== 'number'
     ) {
       throw new Error('cursor missing required fields');
     }

--- a/packages/mcp-core/src/tools/audit_log/get.ts
+++ b/packages/mcp-core/src/tools/audit_log/get.ts
@@ -68,13 +68,13 @@ export default defineTool({
         user_id: e.user_id,
         action_type: e.action_type,
       };
-      if (e.reason !== undefined) result['reason'] = e.reason;
+      if (e.reason !== undefined) result.reason = e.reason;
       return result;
     });
     const lines = entries.map((e) => {
       const reasonStr =
-        e['reason'] !== undefined ? wrapUntrusted(String(e['reason']), 'audit_reason') : '';
-      return `- entry ${e['id']}: action ${e['action_type']}, mod \`user:${e['user_id'] ?? '?'}\` → target \`${e['target_id'] ?? '?'}\` ${reasonStr}`;
+        e.reason !== undefined ? wrapUntrusted(String(e.reason), 'audit_reason') : '';
+      return `- entry ${e.id}: action ${e.action_type}, mod \`user:${e.user_id ?? '?'}\` → target \`${e.target_id ?? '?'}\` ${reasonStr}`;
     });
     return dualResult({
       text: `**${entries.length} audit log entr${entries.length === 1 ? 'y' : 'ies'}**:\n${lines.join('\n')}`,

--- a/packages/mcp-core/src/tools/channels/get.ts
+++ b/packages/mcp-core/src/tools/channels/get.ts
@@ -60,9 +60,9 @@ export default defineTool({
       topic: c.topic ?? null,
       rate_limit_per_user: c.rate_limit_per_user ?? 0,
     };
-    if (c.guild_id !== undefined) data['guild_id'] = c.guild_id;
+    if (c.guild_id !== undefined) data.guild_id = c.guild_id;
     return dualResult({
-      text: `**#${c.name}** (\`channel:${c.id}\`, type ${c.type})\nTopic: ${topicWrapped}\nSlowmode: ${data['rate_limit_per_user']}s`,
+      text: `**#${c.name}** (\`channel:${c.id}\`, type ${c.type})\nTopic: ${topicWrapped}\nSlowmode: ${data.rate_limit_per_user}s`,
       data,
     });
   },

--- a/packages/mcp-core/src/tools/components-v2/build_container.test.ts
+++ b/packages/mcp-core/src/tools/components-v2/build_container.test.ts
@@ -43,6 +43,6 @@ describe('components_v2_build_container', () => {
       { components: [{ type: 10, content: 'hi' }] },
       { signal: new AbortController().signal },
     )) as { isError: boolean; structuredContent: { component: Record<string, unknown> } };
-    expect(r.structuredContent.component['accent_color']).toBeUndefined();
+    expect(r.structuredContent.component.accent_color).toBeUndefined();
   });
 });

--- a/packages/mcp-core/src/tools/components-v2/build_container.ts
+++ b/packages/mcp-core/src/tools/components-v2/build_container.ts
@@ -39,8 +39,8 @@ export default defineTool({
       type: 17,
       components: args.components,
     };
-    if (args.accent_color !== undefined) component['accent_color'] = args.accent_color;
-    if (args.spoiler !== undefined) component['spoiler'] = args.spoiler;
+    if (args.accent_color !== undefined) component.accent_color = args.accent_color;
+    if (args.spoiler !== undefined) component.spoiler = args.spoiler;
     return dualResult({ text: 'Built Container.', data: { component } });
   },
 });

--- a/packages/mcp-core/src/tools/components-v2/build_media_gallery.ts
+++ b/packages/mcp-core/src/tools/components-v2/build_media_gallery.ts
@@ -33,8 +33,8 @@ export default defineTool({
       type: 12,
       items: args.items.map((it) => {
         const item: Record<string, unknown> = { media: { url: it.url } };
-        if (it.description !== undefined) item['description'] = it.description;
-        if (it.spoiler !== undefined) item['spoiler'] = it.spoiler;
+        if (it.description !== undefined) item.description = it.description;
+        if (it.spoiler !== undefined) item.spoiler = it.spoiler;
         return item;
       }),
     };

--- a/packages/mcp-core/src/tools/components-v2/build_section.ts
+++ b/packages/mcp-core/src/tools/components-v2/build_section.ts
@@ -44,7 +44,7 @@ export default defineTool({
       type: 9,
       components: args.text.map((t) => ({ type: 10, content: t })),
     };
-    if (args.accessory !== undefined) component['accessory'] = args.accessory;
+    if (args.accessory !== undefined) component.accessory = args.accessory;
     return dualResult({ text: 'Built Section.', data: { component } });
   },
 });

--- a/packages/mcp-core/src/tools/components-v2/preview-tool.ts
+++ b/packages/mcp-core/src/tools/components-v2/preview-tool.ts
@@ -23,6 +23,6 @@ export default defineTool({
   idempotent: true,
   handler: async (args) => {
     const ascii = renderPreview(args.components as never);
-    return dualResult({ text: '```\n' + ascii + '\n```', data: { ascii } });
+    return dualResult({ text: `\`\`\`\n${ascii}\n\`\`\``, data: { ascii } });
   },
 });

--- a/packages/mcp-core/src/tools/components-v2/send.ts
+++ b/packages/mcp-core/src/tools/components-v2/send.ts
@@ -59,7 +59,7 @@ export default defineTool({
       flags: IS_COMPONENTS_V2,
       components: args.components,
     };
-    if (args.allowed_mentions !== undefined) body['allowed_mentions'] = args.allowed_mentions;
+    if (args.allowed_mentions !== undefined) body.allowed_mentions = args.allowed_mentions;
     const m = (await container.rest.post(Routes.channelMessages(args.channel_id), {
       body,
     })) as SentMessage;

--- a/packages/mcp-core/src/tools/guild/get.ts
+++ b/packages/mcp-core/src/tools/guild/get.ts
@@ -61,7 +61,7 @@ export default defineTool({
       preferred_locale: g.preferred_locale,
       features: g.features,
     };
-    if (g.member_count !== undefined) data['member_count'] = g.member_count;
+    if (g.member_count !== undefined) data.member_count = g.member_count;
     return dualResult({
       text: `**Guild ${wrappedName}** (\`guild:${g.id}\`)\nOwner: \`user:${g.owner_id}\`\nMembers: ${g.member_count ?? '?'}\nDescription: ${wrappedDesc}\nFeatures: ${g.features.join(', ') || '_(none)_'}`,
       data,

--- a/packages/mcp-core/src/tools/messages/read.ts
+++ b/packages/mcp-core/src/tools/messages/read.ts
@@ -98,8 +98,8 @@ export default defineTool({
       channel_id: args.channel_id,
     };
     if (messages.length > 0) {
-      data['oldest_id'] = messages[messages.length - 1]!.id;
-      data['newest_id'] = messages[0]!.id;
+      data.oldest_id = messages[messages.length - 1]!.id;
+      data.newest_id = messages[0]!.id;
     }
 
     return dualResult({ text: wrappedText, data });

--- a/packages/mcp-core/src/tools/meta/pipeline.test.ts
+++ b/packages/mcp-core/src/tools/meta/pipeline.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import mcpPipeline from './pipeline.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+const ok = (data: Record<string, unknown>): CallToolResult => ({
+  isError: false,
+  content: [{ type: 'text', text: 'ok' }],
+  structuredContent: data,
+});
+
+describe('mcp_pipeline tool', () => {
+  it('exposes correct metadata', () => {
+    const T = mcpPipeline;
+    const t = new T(
+      { name: 'mcp_pipeline', path: 'inline', root: 'inline', store: null as never },
+      { name: 'mcp_pipeline', enabled: true },
+    );
+    expect(t.name).toBe('mcp_pipeline');
+    expect(t.category).toBe('meta');
+    expect(t.annotations.openWorldHint).toBe(true);
+  });
+
+  it('refuses recursive mcp_pipeline calls (no nested pipelines)', async () => {
+    const T = mcpPipeline;
+    const t = new T(
+      { name: 'mcp_pipeline', path: 'inline', root: 'inline', store: null as never },
+      { name: 'mcp_pipeline', enabled: true },
+    );
+    const invoke = vi.fn();
+    const result = (await t.run(
+      { steps: [{ id: 'nest', tool: 'mcp_pipeline', args: { steps: [] } }] },
+      { signal: new AbortController().signal, invoke } as never,
+    )) as { isError?: boolean; structuredContent?: { aborted: boolean; steps: Array<{ status: string; error?: { code: string } }> } };
+    expect(result.structuredContent?.aborted).toBe(true);
+    expect(result.structuredContent?.steps[0]!.status).toBe('error');
+    expect(result.structuredContent?.steps[0]!.error?.code).toBe('PIPELINE_RECURSION');
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('forwards each step to the injected invoke function', async () => {
+    const T = mcpPipeline;
+    const t = new T(
+      { name: 'mcp_pipeline', path: 'inline', root: 'inline', store: null as never },
+      { name: 'mcp_pipeline', enabled: true },
+    );
+    const invoke = vi.fn().mockResolvedValue(ok({ count: 3 }));
+    const result = (await t.run(
+      {
+        steps: [
+          { id: 's1', tool: 'channels_list', args: { guild_id: 'g1' } },
+          { id: 's2', tool: 'roles_list', args: { guild_id: 'g1' } },
+        ],
+      },
+      { signal: new AbortController().signal, invoke } as never,
+    )) as { structuredContent: { steps: Array<{ id: string; status: string }> } };
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke.mock.calls[0]![0]).toBe('channels_list');
+    expect(invoke.mock.calls[1]![0]).toBe('roles_list');
+    expect(result.structuredContent.steps).toHaveLength(2);
+    expect(result.structuredContent.steps.every((s) => s.status === 'success')).toBe(true);
+  });
+});

--- a/packages/mcp-core/src/tools/meta/pipeline.test.ts
+++ b/packages/mcp-core/src/tools/meta/pipeline.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
-import mcpPipeline from './pipeline.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it, vi } from 'vitest';
+import mcpPipeline from './pipeline.js';
 
 const ok = (data: Record<string, unknown>): CallToolResult => ({
   isError: false,
@@ -30,10 +30,16 @@ describe('mcp_pipeline tool', () => {
     const result = (await t.run(
       { steps: [{ id: 'nest', tool: 'mcp_pipeline', args: { steps: [] } }] },
       { signal: new AbortController().signal, invoke } as never,
-    )) as { isError?: boolean; structuredContent?: { aborted: boolean; steps: Array<{ status: string; error?: { code: string } }> } };
+    )) as {
+      isError?: boolean;
+      structuredContent?: {
+        aborted: boolean;
+        steps: Array<{ status: string; error?: { code: string } }>;
+      };
+    };
     expect(result.structuredContent?.aborted).toBe(true);
-    expect(result.structuredContent?.steps[0]!.status).toBe('error');
-    expect(result.structuredContent?.steps[0]!.error?.code).toBe('PIPELINE_RECURSION');
+    expect(result.structuredContent?.steps[0]?.status).toBe('error');
+    expect(result.structuredContent?.steps[0]?.error?.code).toBe('PIPELINE_RECURSION');
     expect(invoke).not.toHaveBeenCalled();
   });
 

--- a/packages/mcp-core/src/tools/meta/pipeline.ts
+++ b/packages/mcp-core/src/tools/meta/pipeline.ts
@@ -1,0 +1,136 @@
+import { z } from 'zod';
+import { defineTool } from '../_lib/defineTool.js';
+import { dualResult } from '../_lib/response.js';
+import { executePipeline, type Step, type StepResult } from '../../pipeline/executor.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+interface RunCtxWithInvoke {
+  readonly signal: AbortSignal;
+  readonly invoke: (name: string, args: unknown, signal: AbortSignal) => Promise<CallToolResult>;
+}
+
+const StepSchema = z.object({
+  id: z
+    .string()
+    .regex(/^[a-z][a-z0-9_]{0,63}$/i)
+    .optional()
+    .describe('Reference name for interpolation. Defaults to step_<index>.'),
+  tool: z.string().min(1).describe('Tool name to call. Must exist; not mcp_pipeline (no recursion).'),
+  args: z.record(z.string(), z.unknown()).describe('Tool arguments. String fields support {{step_id.path}} interpolation.'),
+  save_as: z.string().min(1).optional().describe('Save result under this variable name in addition to step ID.'),
+  if: z.string().min(1).optional().describe('Path to truthy check. Step skipped if path resolves falsy. Example: "{{step1.count}}".'),
+  continue_on_error: z.boolean().default(false).describe('If true, pipeline continues after this step fails. Default aborts.'),
+});
+
+export default defineTool({
+  name: 'mcp_pipeline',
+  category: 'meta',
+  description: [
+    '**Purpose**: Execute a sequence of MCP tool calls in one request. Variables from earlier steps interpolate into later steps via `{{step_id.path}}`.',
+    '',
+    '**When to use**: when a workflow needs ≥2 sequential calls (e.g., list channels → find by name → send message). Reduces N round-trips to 1.',
+    '',
+    '**When NOT to use**: parallel-safe independent calls — issue them as separate tools/call requests. Long-running batch ops — use the dedicated bulk tool (Plan 7+) so each operation can fail independently.',
+    '',
+    '**Step shape**: `{id?, tool, args, save_as?, if?, continue_on_error?}`. `args` may contain `{{step_id.path}}` placeholders. `if` is a path check; the step skips when the path resolves to falsy.',
+    '',
+    '**Example**:',
+    '```',
+    '{steps:[',
+    '  {id:"channels", tool:"channels_list", args:{guild_id:"123"}},',
+    '  {id:"send",     tool:"messages_send", args:{channel_id:"{{channels.channels[0].id}}", content:"hi"}}',
+    ']}',
+    '```',
+    '',
+    '**Returns**: `{steps:[{id, tool, status, result?, error?, duration_ms}], variables, total_duration_ms, aborted}`. Each step status is `success | error | skipped`.',
+    '',
+    '**Limits**: max 20 steps per pipeline. Nested `mcp_pipeline` rejected (no recursion).',
+  ].join('\n'),
+  inputSchema: {
+    steps: z.array(StepSchema).min(1).max(20).describe('Ordered steps. Max 20 per pipeline.'),
+  },
+  outputSchema: {
+    steps: z.array(
+      z.object({
+        id: z.string(),
+        tool: z.string(),
+        status: z.enum(['success', 'error', 'skipped']),
+        result: z.unknown().optional(),
+        error: z
+          .object({ code: z.string(), message: z.string(), retriable: z.boolean() })
+          .optional(),
+        duration_ms: z.number(),
+      }),
+    ),
+    variables: z.record(z.string(), z.unknown()),
+    total_duration_ms: z.number(),
+    aborted: z.boolean(),
+  },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  handler: async (args, ctx) => {
+    const runCtx = ctx as RunCtxWithInvoke;
+    const invoke = runCtx.invoke;
+
+    const recursionViolation = args.steps.find((s) => s.tool === 'mcp_pipeline');
+    if (recursionViolation !== undefined) {
+      const stepResults: StepResult[] = args.steps.map((s, i) => {
+        const id = s.id ?? `step_${i}`;
+        if (s.tool === 'mcp_pipeline') {
+          return {
+            id,
+            tool: s.tool,
+            status: 'error',
+            error: {
+              code: 'PIPELINE_RECURSION',
+              message: 'Nested mcp_pipeline calls are not permitted (v1).',
+              retriable: false,
+            },
+            duration_ms: 0,
+          };
+        }
+        return {
+          id,
+          tool: s.tool,
+          status: 'skipped',
+          duration_ms: 0,
+        };
+      });
+      return dualResult({
+        text: '**Pipeline rejected**: nested mcp_pipeline calls are not permitted.',
+        data: {
+          steps: stepResults,
+          variables: {},
+          total_duration_ms: 0,
+          aborted: true,
+        },
+      });
+    }
+
+    const result = await executePipeline(args.steps as readonly Step[], invoke, { signal: runCtx.signal });
+    const summary =
+      `**Pipeline ${result.aborted ? '⚠️ aborted' : '✅ complete'}** — ` +
+      `${result.steps.filter((s) => s.status === 'success').length}/${result.steps.length} success` +
+      ` (${result.total_duration_ms.toFixed(0)}ms)\n` +
+      result.steps
+        .map(
+          (s) =>
+            `- ${s.id} (${s.tool}) — ${s.status}${s.error !== undefined ? ` [${s.error.code}]` : ''} (${s.duration_ms.toFixed(0)}ms)`,
+        )
+        .join('\n');
+
+    return dualResult({
+      text: summary,
+      data: {
+        steps: result.steps.map((s) => ({ ...s })),
+        variables: result.variables,
+        total_duration_ms: result.total_duration_ms,
+        aborted: result.aborted,
+      },
+    });
+  },
+});

--- a/packages/mcp-core/src/tools/meta/pipeline.ts
+++ b/packages/mcp-core/src/tools/meta/pipeline.ts
@@ -1,8 +1,8 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
+import { executePipeline, type Step, type StepResult } from '../../pipeline/executor.js';
 import { defineTool } from '../_lib/defineTool.js';
 import { dualResult } from '../_lib/response.js';
-import { executePipeline, type Step, type StepResult } from '../../pipeline/executor.js';
-import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 interface RunCtxWithInvoke {
   readonly signal: AbortSignal;
@@ -15,11 +15,29 @@ const StepSchema = z.object({
     .regex(/^[a-z][a-z0-9_]{0,63}$/i)
     .optional()
     .describe('Reference name for interpolation. Defaults to step_<index>.'),
-  tool: z.string().min(1).describe('Tool name to call. Must exist; not mcp_pipeline (no recursion).'),
-  args: z.record(z.string(), z.unknown()).describe('Tool arguments. String fields support {{step_id.path}} interpolation.'),
-  save_as: z.string().min(1).optional().describe('Save result under this variable name in addition to step ID.'),
-  if: z.string().min(1).optional().describe('Path to truthy check. Step skipped if path resolves falsy. Example: "{{step1.count}}".'),
-  continue_on_error: z.boolean().default(false).describe('If true, pipeline continues after this step fails. Default aborts.'),
+  tool: z
+    .string()
+    .min(1)
+    .describe('Tool name to call. Must exist; not mcp_pipeline (no recursion).'),
+  args: z
+    .record(z.string(), z.unknown())
+    .describe('Tool arguments. String fields support {{step_id.path}} interpolation.'),
+  save_as: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Save result under this variable name in addition to step ID.'),
+  if: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      'Path to truthy check. Step skipped if path resolves falsy. Example: "{{step1.count}}".',
+    ),
+  continue_on_error: z
+    .boolean()
+    .default(false)
+    .describe('If true, pipeline continues after this step fails. Default aborts.'),
 });
 
 export default defineTool({
@@ -111,7 +129,9 @@ export default defineTool({
       });
     }
 
-    const result = await executePipeline(args.steps as readonly Step[], invoke, { signal: runCtx.signal });
+    const result = await executePipeline(args.steps as readonly Step[], invoke, {
+      signal: runCtx.signal,
+    });
     const summary =
       `**Pipeline ${result.aborted ? '⚠️ aborted' : '✅ complete'}** — ` +
       `${result.steps.filter((s) => s.status === 'success').length}/${result.steps.length} success` +

--- a/packages/mcp-core/src/tools/users/get_current.ts
+++ b/packages/mcp-core/src/tools/users/get_current.ts
@@ -44,7 +44,7 @@ export default defineTool({
       avatar: u.avatar,
       bot: u.bot,
     };
-    if (u.verified !== undefined) data['verified'] = u.verified;
+    if (u.verified !== undefined) data.verified = u.verified;
     return dualResult({
       text: `**${u.username}** (\`user:${u.id}\`, ${u.bot ? 'bot' : 'user'})`,
       data,

--- a/test/mocks/discord-handlers.ts
+++ b/test/mocks/discord-handlers.ts
@@ -48,7 +48,7 @@ export const handlers = [
   http.get(`${DISCORD_API}/guilds/:guildId/channels`, async ({ params }) => {
     return HttpResponse.json([
       {
-        id: 'ch1',
+        id: '111122223333444401',
         name: 'general',
         type: 0,
         position: 0,
@@ -57,7 +57,7 @@ export const handlers = [
         guild_id: params['guildId'],
       },
       {
-        id: 'ch2',
+        id: '111122223333444402',
         name: 'announcements',
         type: 5,
         position: 1,
@@ -66,7 +66,7 @@ export const handlers = [
         guild_id: params['guildId'],
       },
       {
-        id: 'ch3',
+        id: '111122223333444403',
         name: 'voice-lobby',
         type: 2,
         position: 2,

--- a/test/mocks/discord-handlers.ts
+++ b/test/mocks/discord-handlers.ts
@@ -13,7 +13,7 @@ export const handlers = [
     };
     return HttpResponse.json({
       id: '999000999000999000',
-      channel_id: params['channelId'],
+      channel_id: params.channelId,
       content: body.content ?? '',
       tts: body.tts ?? false,
       timestamp: '2026-04-28T12:00:00.000000+00:00',
@@ -29,7 +29,7 @@ export const handlers = [
     const limit = Number(url.searchParams.get('limit') ?? 50);
     const items = Array.from({ length: Math.min(limit, 3) }, (_, i) => ({
       id: `msg_${i + 1}`,
-      channel_id: params['channelId'],
+      channel_id: params.channelId,
       content: `message ${i + 1} content`,
       author: {
         id: `user_${i + 1}`,
@@ -54,7 +54,7 @@ export const handlers = [
         position: 0,
         parent_id: null,
         nsfw: false,
-        guild_id: params['guildId'],
+        guild_id: params.guildId,
       },
       {
         id: '111122223333444402',
@@ -63,7 +63,7 @@ export const handlers = [
         position: 1,
         parent_id: null,
         nsfw: false,
-        guild_id: params['guildId'],
+        guild_id: params.guildId,
       },
       {
         id: '111122223333444403',
@@ -71,14 +71,14 @@ export const handlers = [
         type: 2,
         position: 2,
         parent_id: null,
-        guild_id: params['guildId'],
+        guild_id: params.guildId,
       },
     ]);
   }),
   // channels_get — must come AFTER the :channelId/messages route
   http.get(`${DISCORD_API}/channels/:channelId`, async ({ params }) => {
     return HttpResponse.json({
-      id: params['channelId'],
+      id: params.channelId,
       name: 'general',
       type: 0,
       position: 0,
@@ -93,7 +93,7 @@ export const handlers = [
   http.get(`${DISCORD_API}/guilds/:guildId/members/:userId`, async ({ params }) => {
     return HttpResponse.json({
       user: {
-        id: params['userId'],
+        id: params.userId,
         username: 'alice',
         global_name: 'Alice',
         avatar: 'abc123',
@@ -168,7 +168,7 @@ export const handlers = [
   // guild_get
   http.get(`${DISCORD_API}/guilds/:guildId`, async ({ params }) => {
     return HttpResponse.json({
-      id: params['guildId'],
+      id: params.guildId,
       name: 'My Test Server',
       icon: 'icon_hash',
       owner_id: 'owner1',
@@ -195,8 +195,8 @@ export const handlers = [
     return HttpResponse.json([
       {
         id: 'cmd1',
-        application_id: params['appId'],
-        guild_id: params['guildId'],
+        application_id: params.appId,
+        guild_id: params.guildId,
         name: 'ping',
         description: 'Ping the bot',
         type: 1,
@@ -211,7 +211,7 @@ export const handlers = [
         id: 'wh1',
         name: 'CI Notifier',
         type: 1,
-        channel_id: params['channelId'],
+        channel_id: params.channelId,
         application_id: null,
         avatar: null,
       },
@@ -227,8 +227,8 @@ export const handlers = [
         components?: unknown[];
       };
       return HttpResponse.json({
-        id: params['messageId'],
-        channel_id: params['channelId'],
+        id: params.messageId,
+        channel_id: params.channelId,
         content: body.content ?? '',
         edited_timestamp: '2026-04-28T13:00:00.000000+00:00',
         ...(body.flags !== undefined && { flags: body.flags }),


### PR DESCRIPTION
## Summary

- **`mcp_pipeline` tool** in category `meta` — chain up to 20 tool calls in one MCP request.
- **Variable interpolation** `{{step_id.path}}` — single-template returns raw value (type-preserved), multi-template stringifies.
- **Conditional execution** via `if` — path truthy check.
- **Error policy** — `continue_on_error` flag per-step (default abort on first error).
- **`save_as` aliasing** — store result under both step ID and the alias.
- **Recursion guard** — nested `mcp_pipeline` calls rejected with `PIPELINE_RECURSION`.
- **20-step cap** to reduce DoS surface.
- **Each step routes through the full middleware chain** (validate + precondition) so per-step errors are properly formatted and preconditions like `ConfirmRequired` still gate destructive ops mid-pipeline.

## Stats

- 24 tools total (23 prior + `mcp_pipeline`)
- 205 tests passing
- Tag: `v0.4.0`

## USP

No Discord MCP server in the landscape (PaSympa, quadslab, discord-ops, ...) currently has a pipeline executor. Plan 4 ships THE differentiator.

## Test Plan

- [x] `pnpm lint && pnpm typecheck && pnpm build && pnpm test` all green
- [x] Smoke test: 24 tools advertised
- [x] Contract test: 2-step pipeline executes, recursion rejected
- [ ] CI green on this PR

## What's deferred

- **Tasks SEP-1686** durable call-now/fetch-later — defer until MCP SDK stabilizes the API (currently experimental, only Claude Code + VS Code support it).
- Intelligence sampling tools → Plan 5
- Discord Gateway / live resource updates → Plan 6
- Remaining 130+ tools → Plan 7
- Telemetry / cockatiel resilience middlewares → Plan 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)