### PR TITLE
Plan 9 — CLI sub-commands (doctor / init / migrate)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Force LF line endings for all text files (silences Windows CRLF biome warnings)
+* text=auto eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.ico binary
+*.gif binary

--- a/README.md
+++ b/README.md
@@ -1,10 +1,103 @@
 # discord-mcp
 
-TypeScript Model Context Protocol server exposing the Discord REST API to AI agents.
+Production-grade Model Context Protocol server exposing the full Discord REST API to AI agents.
 
-**Status:** Pre-alpha (v0.0). Not yet published.
+**Status**: v0.9.0 · 192 tools · OTel-instrumented · Cockatiel-resilient · Audit-logged
 
 See [design spec](docs/superpowers/specs/2026-04-28-discord-mcp-design.md) for architecture.
+
+## Quick start
+
+```bash
+# 1. Install
+npm install -g @discord-mcp/cli  # or use npx
+
+# 2. Bootstrap config for your MCP client
+discord-mcp init --client claude-desktop --token "Bot YOUR.BOT.TOKEN"
+
+# 3. Verify configuration
+discord-mcp doctor --online
+
+# 4. Run (or let your MCP client launch it)
+discord-mcp serve
+```
+
+## Subcommands
+
+### `discord-mcp serve` (default)
+
+Start the stdio MCP server. This is the default action when no subcommand is given.
+
+**Flags**:
+- `--gateway` — Enable Discord Gateway resource subscriptions (lazy-imports discord.js)
+
+### `discord-mcp doctor`
+
+Diagnose configuration and connectivity. Exits 0 (healthy), 1 (warnings), or 2 (errors).
+
+**Flags**:
+- `--online` — Run network checks (Discord token verify, OTel reachability)
+- `--json` — Output as JSON for CI consumption
+
+**Offline checks**: node-version, token-format, env-vars, audit-sink, client-caps
+**Online checks** (with `--online`): token-online, otel-reachable
+
+### `discord-mcp init`
+
+Bootstrap configuration + generate MCP client config snippet.
+
+**Flags**:
+- `--token <token>` — Discord bot token (or `${env:DISCORD_TOKEN}` placeholder)
+- `--client <id>` — Client: `claude-desktop`, `claude-code`, `cursor`, or `generic`
+- `--output <path>` — Write snippet to file (default: stdout)
+- `--force` — Overwrite existing output file
+- `--gateway` — Enable Discord Gateway in generated config
+- `--json` — JSON output for CI
+
+When stdin is a TTY and flags are missing, init runs an interactive wizard.
+
+### `discord-mcp migrate`
+
+Migrate from another Discord/MCP setup. Exits 0 (all mapped), 1 (some unmapped), 2 (errors).
+
+**Flags**:
+- `--from <adapter>` — Source adapter id (run without `--from` to list)
+- `--source <path>` — Path to source repo (default: cwd)
+- `--json` — JSON output
+
+**Available adapters**: `hubdustry-go-mcp` (reference impl). More in Plan 11.
+
+## Tool surface
+
+192 tools across:
+- messages (12)
+- channels (14)
+- threads (6)
+- members (14)
+- roles (5)
+- guild (16)
+- audit_log (1)
+- webhooks (13)
+- events (6)
+- commands (15)
+- users (6)
+- components-v2 (8)
+- intelligence (5)
+- meta (1)
+- reactions (5)
+- emojis (5)
+- app_emojis (5)
+- stickers (7)
+- invites (4)
+- automod (5)
+- interactions (8)
+- application (5)
+- stage_instances (4)
+- soundboard (7)
+- polls (2)
+- voice (3)
+- onboarding (2)
+- monetization (8)
 
 ## Local development
 
@@ -31,8 +124,14 @@ Then use the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) 
 npx -y @modelcontextprotocol/inspector node packages/mcp-server/dist/cli.js
 ```
 
-Open the Inspector UI at <http://localhost:5173>, click `tools/list`, and you should see `messages_send`. Try calling it with `{channel_id: "<your channel>", content: "test"}`.
+Open the Inspector UI at <http://localhost:5173>, click `tools/list`, and you should see all 192 tools.
 
-## Status
+## Documentation
 
-This repository implements **Plan 0 — Project skeleton** from `docs/superpowers/plans/`. Subsequent plans add the remaining 174 tools, middleware chain, Components V2, pipeline executor, and distribution polish.
+- [Operations: telemetry](docs/operations/telemetry.md) — OTel setup
+- [Operations: resilience](docs/operations/resilience.md) — Tuning retry/timeout/circuit
+- [Operations: audit](docs/operations/audit.md) — Audit sinks + compliance
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discord-mcp/core",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-core/src/config.test.ts
+++ b/packages/mcp-core/src/config.test.ts
@@ -43,9 +43,9 @@ describe('loadConfig', () => {
       expect(overridden.OTEL_SERVICE_NAME).toBe('custom');
     });
 
-    it('OTEL_SERVICE_VERSION defaults to "0.8.0" and accepts override', () => {
+    it('OTEL_SERVICE_VERSION defaults to "0.9.0" and accepts override', () => {
       const def = loadConfig({ DISCORD_TOKEN: VALID_TOKEN } as NodeJS.ProcessEnv);
-      expect(def.OTEL_SERVICE_VERSION).toBe('0.8.0');
+      expect(def.OTEL_SERVICE_VERSION).toBe('0.9.0');
       const overridden = loadConfig({
         DISCORD_TOKEN: VALID_TOKEN,
         OTEL_SERVICE_VERSION: '1.2.3',

--- a/packages/mcp-core/src/config.ts
+++ b/packages/mcp-core/src/config.ts
@@ -17,7 +17,7 @@ const ConfigSchema = z.object({
   // Master switch. When false, mcp-server skips SDK boot entirely (default behavior).
   OTEL_ENABLED: boolish(false),
   OTEL_SERVICE_NAME: z.string().default('discord-mcp'),
-  OTEL_SERVICE_VERSION: z.string().default('0.8.0'),
+  OTEL_SERVICE_VERSION: z.string().default('0.9.0'),
   // OTLP collector endpoint (e.g. http://localhost:4318). Optional — when unset
   // the SDK still boots (if OTEL_CONSOLE_EXPORTER=true) or stays inert.
   OTEL_EXPORTER_OTLP_ENDPOINT: z.url().optional(),

--- a/packages/mcp-core/src/telemetry/conventions.ts
+++ b/packages/mcp-core/src/telemetry/conventions.ts
@@ -39,4 +39,4 @@ export const ATTR_ERROR_TYPE = 'error.type';
 
 // --- Tracer / Meter identity (also used by middleware) ---
 export const TELEMETRY_INSTRUMENTATION_NAME = '@discord-mcp/core';
-export const TELEMETRY_INSTRUMENTATION_VERSION = '0.8.0';
+export const TELEMETRY_INSTRUMENTATION_VERSION = '0.9.0';

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discord-mcp/cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": false,
   "type": "module",
   "mcpName": "io.github.jhm1909/discord-mcp",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -39,7 +39,9 @@
     "build": "tsdown",
     "dev": "tsdown --watch",
     "test": "vitest run --passWithNoTests",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepack": "node -e \"require('node:fs').copyFileSync('../../README.md','README.md');require('node:fs').copyFileSync('../../LICENSE','LICENSE');\"",
+    "postpack": "node -e \"try{require('node:fs').unlinkSync('README.md');require('node:fs').unlinkSync('LICENSE');}catch{}\""
   },
   "dependencies": {
     "@discord-mcp/core": "workspace:*",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -6,7 +6,8 @@
   "mcpName": "io.github.jhm1909/discord-mcp",
   "description": "Discord MCP server — stdio transport CLI",
   "bin": {
-    "discord-mcp": "./dist/cli.js"
+    "discord-mcp": "./dist/cli.js",
+    "discord-mcp-server": "./dist/cli.js"
   },
   "main": "./dist/cli.js",
   "files": [

--- a/packages/mcp-server/src/cli.smoke.test.ts
+++ b/packages/mcp-server/src/cli.smoke.test.ts
@@ -1,0 +1,88 @@
+/**
+ * CLI binary smoke test (Plan 9 Phase F).
+ *
+ * Spawns the built `dist/cli.js` as a real subprocess and asserts:
+ * 1. `--version` prints the package version.
+ * 2. `--help` lists all four sub-commands.
+ * 3. `doctor --json` (without DISCORD_TOKEN) exits non-zero with parseable
+ *    JSON that flags the missing token.
+ *
+ * Requires `pnpm build` to have run; the test self-skips when `dist/cli.js`
+ * is absent so incremental dev runs don't fail. CI runs `pnpm build` before
+ * `pnpm test`, so the smoke gate fires there.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import packageJson from '../package.json' with { type: 'json' };
+
+const here = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(here, '..', 'dist', 'cli.js');
+const cliBuilt = existsSync(cliPath);
+
+/** Run the built CLI and capture both stdout and exit code. */
+function runCli(
+  args: string[],
+  extraEnv: NodeJS.ProcessEnv = {},
+): {
+  stdout: string;
+  stderr: string;
+  status: number | null;
+} {
+  try {
+    const stdout = execFileSync(process.execPath, [cliPath, ...args], {
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH ?? '', ...extraEnv },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', status: 0 };
+  } catch (e) {
+    const err = e as {
+      stdout?: string | Buffer;
+      stderr?: string | Buffer;
+      status?: number | null;
+    };
+    const decode = (v: string | Buffer | undefined): string =>
+      v === undefined ? '' : typeof v === 'string' ? v : v.toString('utf8');
+    return {
+      stdout: decode(err.stdout),
+      stderr: decode(err.stderr),
+      status: err.status ?? null,
+    };
+  }
+}
+
+describe.skipIf(!cliBuilt)('cli binary smoke (post-build)', () => {
+  it('--version prints package version', () => {
+    const { stdout, stderr, status } = runCli(['--version']);
+    const combined = stdout + stderr;
+    expect(combined).toContain(packageJson.version);
+    expect(status).toBe(0);
+  });
+
+  it('--help lists all four subcommands', () => {
+    const { stdout, stderr, status } = runCli(['--help']);
+    const combined = stdout + stderr;
+    expect(combined).toContain('serve');
+    expect(combined).toContain('doctor');
+    expect(combined).toContain('init');
+    expect(combined).toContain('migrate');
+    expect(status).toBe(0);
+  });
+
+  it('doctor --json without token exits non-zero with parseable JSON', () => {
+    const { stdout, status } = runCli(['doctor', '--json']);
+    expect(status).not.toBe(0);
+    const parsed = JSON.parse(stdout) as { ok: boolean; exitCode: number };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.exitCode).toBe(2);
+  });
+});
+
+describe.skipIf(cliBuilt)('cli binary smoke (skipped — no build)', () => {
+  it('skipped because dist/cli.js is missing; run `pnpm build` first', () => {
+    expect(cliBuilt).toBe(false);
+  });
+});

--- a/packages/mcp-server/src/cli.test.ts
+++ b/packages/mcp-server/src/cli.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock startStdio so `serve` is a no-op. Hoisted before cli.ts loads.
+vi.mock('./transports/stdio.js', () => ({
+  startStdio: vi.fn(async () => {
+    // No-op: real startStdio would block on the MCP transport.
+  }),
+}));
+
+// Now import cli — its top-level auto-parse is gated behind VITEST=true.
+const { program } = await import('./cli.js');
+const { startStdio } = await import('./transports/stdio.js');
+
+import packageJson from '../package.json' with { type: 'json' };
+
+const originalGateway = process.env.GATEWAY;
+const originalExitCode = process.exitCode;
+
+let stdoutWrites: string[] = [];
+
+beforeEach(() => {
+  stdoutWrites = [];
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    stdoutWrites.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  delete process.env.GATEWAY;
+  process.exitCode = 0;
+  vi.mocked(startStdio).mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalGateway !== undefined) {
+    process.env.GATEWAY = originalGateway;
+  } else {
+    delete process.env.GATEWAY;
+  }
+  process.exitCode = originalExitCode;
+});
+
+function stdoutOutput(): string {
+  return stdoutWrites.join('');
+}
+
+/**
+ * Drive commander.parseAsync with synthetic argv. We override commander's
+ * default exit/output behavior so version/help don't terminate the test
+ * process and so we can capture their output via our stdout spy.
+ */
+async function runCli(args: string[]): Promise<void> {
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: (str) => {
+      stdoutWrites.push(str);
+    },
+    writeErr: (str) => {
+      stdoutWrites.push(str);
+    },
+  });
+  try {
+    await program.parseAsync(['node', 'cli.js', ...args]);
+  } catch (e) {
+    // commander.exitOverride() throws CommanderError for --version / --help
+    // and unknown commands. Re-throw only if it's not one of those terminal
+    // codes so tests can still see real failures.
+    const code = (e as { code?: string } | undefined)?.code;
+    if (
+      code !== 'commander.version' &&
+      code !== 'commander.helpDisplayed' &&
+      code !== 'commander.help'
+    ) {
+      throw e;
+    }
+  }
+}
+
+describe('cli — version + help', () => {
+  it('--version prints package version', async () => {
+    await runCli(['--version']);
+    expect(stdoutOutput()).toContain(packageJson.version);
+  });
+
+  it('--help lists all sub-commands', async () => {
+    await runCli(['--help']);
+    const out = stdoutOutput();
+    expect(out).toContain('serve');
+    expect(out).toContain('doctor');
+    expect(out).toContain('init');
+    expect(out).toContain('migrate');
+  });
+});
+
+describe('cli — serve (default sub-command)', () => {
+  it('bare invocation routes to serve', async () => {
+    await runCli([]);
+    expect(startStdio).toHaveBeenCalledTimes(1);
+    expect(process.env.GATEWAY).toBeUndefined();
+  });
+
+  it('explicit `serve` sub-command works', async () => {
+    await runCli(['serve']);
+    expect(startStdio).toHaveBeenCalledTimes(1);
+  });
+
+  it('serve --gateway sets GATEWAY=1', async () => {
+    await runCli(['serve', '--gateway']);
+    expect(process.env.GATEWAY).toBe('1');
+    expect(startStdio).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('cli — placeholder sub-commands', () => {
+  it('doctor exits with code 2 and prints not-yet-implemented', async () => {
+    await runCli(['doctor']);
+    expect(process.exitCode).toBe(2);
+    expect(stdoutOutput()).toContain('not yet implemented');
+    expect(stdoutOutput()).toContain('doctor');
+  });
+
+  it('doctor accepts --json without breaking option shape', async () => {
+    await runCli(['doctor', '--json']);
+    expect(process.exitCode).toBe(2);
+  });
+
+  it('doctor accepts --online without breaking option shape', async () => {
+    await runCli(['doctor', '--online']);
+    expect(process.exitCode).toBe(2);
+  });
+
+  it('init exits with code 2 and prints not-yet-implemented', async () => {
+    await runCli(['init']);
+    expect(process.exitCode).toBe(2);
+    expect(stdoutOutput()).toContain('not yet implemented');
+    expect(stdoutOutput()).toContain('init');
+  });
+
+  it('migrate exits with code 2 and prints not-yet-implemented', async () => {
+    await runCli(['migrate']);
+    expect(process.exitCode).toBe(2);
+    expect(stdoutOutput()).toContain('not yet implemented');
+    expect(stdoutOutput()).toContain('migrate');
+  });
+});

--- a/packages/mcp-server/src/cli.test.ts
+++ b/packages/mcp-server/src/cli.test.ts
@@ -224,11 +224,12 @@ describe('cli — init sub-command (Plan 9 Phase D)', () => {
   });
 });
 
-describe('cli — placeholder sub-commands', () => {
-  it('migrate exits with code 2 and prints not-yet-implemented', async () => {
+describe('cli — migrate sub-command (Plan 9 Phase E)', () => {
+  it('migrate without --from exits 2 and lists available adapters', async () => {
     await runCli(['migrate']);
     expect(process.exitCode).toBe(2);
-    expect(stdoutOutput()).toContain('not yet implemented');
-    expect(stdoutOutput()).toContain('migrate');
+    const out = stdoutOutput();
+    expect(out).toContain('--from');
+    expect(out).toContain('hubdustry-go-mcp');
   });
 });

--- a/packages/mcp-server/src/cli.test.ts
+++ b/packages/mcp-server/src/cli.test.ts
@@ -111,24 +111,53 @@ describe('cli — serve (default sub-command)', () => {
   });
 });
 
-describe('cli — placeholder sub-commands', () => {
-  it('doctor exits with code 2 and prints not-yet-implemented', async () => {
-    await runCli(['doctor']);
-    expect(process.exitCode).toBe(2);
-    expect(stdoutOutput()).toContain('not yet implemented');
-    expect(stdoutOutput()).toContain('doctor');
+describe('cli — doctor sub-command (Plan 9 Phase B)', () => {
+  // Without DISCORD_TOKEN env, env-vars + token-format checks fail → exit 2.
+  // We deliberately rely on the test runner's real env (no token) to get a
+  // deterministic fail; if a developer has DISCORD_TOKEN exported in their
+  // shell, vitest inherits it and the result would be exit 0 or 1 here. We
+  // strip it explicitly inside the test to prevent that.
+  const savedDiscordToken = process.env.DISCORD_TOKEN;
+  beforeEach(() => {
+    delete process.env.DISCORD_TOKEN;
+  });
+  afterEach(() => {
+    if (savedDiscordToken !== undefined) {
+      process.env.DISCORD_TOKEN = savedDiscordToken;
+    } else {
+      delete process.env.DISCORD_TOKEN;
+    }
   });
 
-  it('doctor accepts --json without breaking option shape', async () => {
+  it('doctor exits with code 2 when token is missing', async () => {
+    await runCli(['doctor']);
+    expect(process.exitCode).toBe(2);
+    // Pretty output mentions the failing checks by id.
+    expect(stdoutOutput()).toContain('token-format');
+    expect(stdoutOutput()).toContain('env-vars');
+  });
+
+  it('doctor accepts --json and emits parseable JSON', async () => {
     await runCli(['doctor', '--json']);
     expect(process.exitCode).toBe(2);
+    const out = stdoutOutput();
+    const parsed = JSON.parse(out);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.exitCode).toBe(2);
+    expect(parsed.data?.checks).toBeDefined();
+    expect(Array.isArray(parsed.data.checks)).toBe(true);
   });
 
   it('doctor accepts --online without breaking option shape', async () => {
+    // Phase B: --online filters checks but no online checks exist yet, so
+    // running with --online still produces the same offline check set
+    // (offline checks have online: false; --online just lifts the filter).
     await runCli(['doctor', '--online']);
     expect(process.exitCode).toBe(2);
   });
+});
 
+describe('cli — placeholder sub-commands', () => {
   it('init exits with code 2 and prints not-yet-implemented', async () => {
     await runCli(['init']);
     expect(process.exitCode).toBe(2);

--- a/packages/mcp-server/src/cli.test.ts
+++ b/packages/mcp-server/src/cli.test.ts
@@ -232,4 +232,12 @@ describe('cli — migrate sub-command (Plan 9 Phase E)', () => {
     expect(out).toContain('--from');
     expect(out).toContain('hubdustry-go-mcp');
   });
+
+  it('migrate --help lists --from / --source / --json', async () => {
+    await runCli(['migrate', '--help']);
+    const out = stdoutOutput();
+    expect(out).toContain('--from');
+    expect(out).toContain('--source');
+    expect(out).toContain('--json');
+  });
 });

--- a/packages/mcp-server/src/cli.test.ts
+++ b/packages/mcp-server/src/cli.test.ts
@@ -59,6 +59,19 @@ async function runCli(args: string[]): Promise<void> {
       stdoutWrites.push(str);
     },
   });
+  // Sub-commands keep their own exit/output config — propagate to all of
+  // them so `discord-mcp init --help` doesn't call process.exit() directly.
+  for (const sub of program.commands) {
+    sub.exitOverride();
+    sub.configureOutput({
+      writeOut: (str) => {
+        stdoutWrites.push(str);
+      },
+      writeErr: (str) => {
+        stdoutWrites.push(str);
+      },
+    });
+  }
   try {
     await program.parseAsync(['node', 'cli.js', ...args]);
   } catch (e) {
@@ -157,14 +170,61 @@ describe('cli — doctor sub-command (Plan 9 Phase B)', () => {
   });
 });
 
-describe('cli — placeholder sub-commands', () => {
-  it('init exits with code 2 and prints not-yet-implemented', async () => {
-    await runCli(['init']);
-    expect(process.exitCode).toBe(2);
-    expect(stdoutOutput()).toContain('not yet implemented');
-    expect(stdoutOutput()).toContain('init');
+describe('cli — init sub-command (Plan 9 Phase D)', () => {
+  // Force non-interactive so init takes the deterministic flag-only path.
+  const originalStdinTTY = process.stdin.isTTY;
+  const originalStdoutTTY = process.stdout.isTTY;
+  beforeEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: false,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: false,
+      configurable: true,
+      writable: true,
+    });
+  });
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: originalStdinTTY,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: originalStdoutTTY,
+      configurable: true,
+      writable: true,
+    });
   });
 
+  it('init --help lists all the new flags', async () => {
+    await runCli(['init', '--help']);
+    const out = stdoutOutput();
+    expect(out).toContain('--client');
+    expect(out).toContain('--token');
+    expect(out).toContain('--gateway');
+    expect(out).toContain('--output');
+    expect(out).toContain('--force');
+    expect(out).toContain('--json');
+  });
+
+  it('init --json --client generic produces parseable JSON with exit code 0', async () => {
+    await runCli(['init', '--json', '--client', 'generic']);
+    expect(process.exitCode).toBe(0);
+    const parsed = JSON.parse(stdoutOutput()) as { ok: boolean; data?: { client?: string } };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data?.client).toBe('generic');
+  });
+
+  it('init --client unknown-client exits with code 2', async () => {
+    await runCli(['init', '--json', '--client', 'unknown-client']);
+    expect(process.exitCode).toBe(2);
+  });
+});
+
+describe('cli — placeholder sub-commands', () => {
   it('migrate exits with code 2 and prints not-yet-implemented', async () => {
     await runCli(['migrate']);
     expect(process.exitCode).toBe(2);

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -1,23 +1,68 @@
 #!/usr/bin/env node
+/**
+ * discord-mcp CLI entry point.
+ *
+ * Plan 9 Phase A: commander sub-command router.
+ * - `serve` is the default sub-command (`isDefault: true`) so a bare
+ *   `discord-mcp` invocation still boots the stdio MCP server.
+ * - `--gateway` lives on `serve`. Bare `discord-mcp --gateway` is
+ *   forwarded to `serve` through commander's default-subcommand passthrough.
+ * - `doctor`, `init`, `migrate` are placeholders that print
+ *   "not yet implemented (Plan 9 Phase X)" and set process.exitCode = 2.
+ *   They are wired now so the option shapes are stable for Phases B/C/D.
+ * - Doctor / init / migrate handlers are lazy-imported (`await import(...)`)
+ *   so cold-start for `serve` (the hot path) is unaffected by their deps.
+ *
+ * `program` is exported so tests can drive `parseAsync` without spawning
+ * a child process. Auto-parse is suppressed under VITEST so tests can
+ * call `parseAsync(['node', 'cli.js', ...args])` with synthetic argv.
+ */
 import { Command } from 'commander';
 import packageJson from '../package.json' with { type: 'json' };
-import { startStdio } from './transports/stdio.js';
+import { serveAction } from './commands/serve.js';
 
-const program = new Command('discord-mcp')
+export const program = new Command('discord-mcp')
   .description('Discord MCP server — stdio transport for AI agents')
-  .version(packageJson.version)
+  .version(packageJson.version);
+
+program
+  .command('serve', { isDefault: true })
+  .description('Start the stdio MCP server (default)')
   .option('--gateway', 'Enable Discord Gateway resource subscriptions (lazy-imports discord.js)')
   .action(async (options: { gateway?: boolean }) => {
-    if (options.gateway === true) {
-      process.env.GATEWAY = '1';
-    }
-    try {
-      await startStdio();
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      console.error(`discord-mcp failed to start: ${msg}`);
-      process.exit(1);
-    }
+    await serveAction(options);
   });
 
-await program.parseAsync(process.argv);
+program
+  .command('doctor')
+  .description('Diagnose configuration, token, and connectivity issues')
+  .option('--json', 'Emit machine-readable JSON instead of pretty output')
+  .option('--online', 'Run online checks against Discord (requires DISCORD_TOKEN)')
+  .action(async (options: { json?: boolean; online?: boolean }) => {
+    const { doctorAction } = await import('./commands/doctor.js');
+    await doctorAction(options);
+  });
+
+program
+  .command('init')
+  .description('Generate a starter mcp.json config and .env scaffold')
+  .action(async () => {
+    const { initAction } = await import('./commands/init.js');
+    await initAction();
+  });
+
+program
+  .command('migrate')
+  .description('Migrate older configs / mcp.json shapes to the current format')
+  .action(async () => {
+    const { migrateAction } = await import('./commands/migrate.js');
+    await migrateAction();
+  });
+
+// Run the parser only when invoked as the bin script (not when imported
+// from tests). Vitest sets VITEST=true for every worker; we use it to
+// suppress auto-parse during unit tests, which import `program` and
+// drive parseAsync directly with synthetic argv.
+if (process.env.VITEST !== 'true') {
+  await program.parseAsync(process.argv);
+}

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
+import packageJson from '../package.json' with { type: 'json' };
 import { startStdio } from './transports/stdio.js';
 
 const program = new Command('discord-mcp')
   .description('Discord MCP server — stdio transport for AI agents')
-  .version('0.0.0')
+  .version(packageJson.version)
   .option('--gateway', 'Enable Discord Gateway resource subscriptions (lazy-imports discord.js)')
   .action(async (options: { gateway?: boolean }) => {
     if (options.gateway === true) {

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -45,11 +45,38 @@ program
 
 program
   .command('init')
-  .description('Generate a starter mcp.json config and .env scaffold')
-  .action(async () => {
-    const { initAction } = await import('./commands/init.js');
-    await initAction();
-  });
+  .description(
+    'Generate an MCP client config snippet (Claude Desktop / Claude Code / Cursor / Generic)',
+  )
+  .option(
+    '--client <id>',
+    'MCP client (claude-desktop|claude-code|cursor|generic). Default: prompt if TTY, else "generic".',
+  )
+  .option(
+    '--token <token>',
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder shown in --help
+    'Discord bot token. WARNING: writes the value into the config file unredacted. Omit to use the ${env:DISCORD_TOKEN} placeholder.',
+  )
+  .option(
+    '--gateway',
+    'Append --gateway to the snippet so the server enables Discord Gateway resource subscriptions',
+  )
+  .option('--output <path>', 'Write the snippet to this path instead of stdout')
+  .option('--force', 'Overwrite the --output path if it already exists')
+  .option('--json', 'Emit machine-readable JSON instead of pretty output')
+  .action(
+    async (options: {
+      client?: string;
+      token?: string;
+      gateway?: boolean;
+      output?: string;
+      force?: boolean;
+      json?: boolean;
+    }) => {
+      const { initAction } = await import('./commands/init.js');
+      await initAction(options);
+    },
+  );
 
 program
   .command('migrate')

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -7,9 +7,9 @@
  *   `discord-mcp` invocation still boots the stdio MCP server.
  * - `--gateway` lives on `serve`. Bare `discord-mcp --gateway` is
  *   forwarded to `serve` through commander's default-subcommand passthrough.
- * - `doctor`, `init`, `migrate` are placeholders that print
- *   "not yet implemented (Plan 9 Phase X)" and set process.exitCode = 2.
- *   They are wired now so the option shapes are stable for Phases B/C/D.
+ * - `doctor`, `init`, `migrate` are real sub-commands as of Plan 9
+ *   Phases B (doctor), D (init), and E (migrate). Each emits a
+ *   structured CommandResult via emitResult().
  * - Doctor / init / migrate handlers are lazy-imported (`await import(...)`)
  *   so cold-start for `serve` (the hot path) is unaffected by their deps.
  *
@@ -80,10 +80,13 @@ program
 
 program
   .command('migrate')
-  .description('Migrate older configs / mcp.json shapes to the current format')
-  .action(async () => {
+  .description('Migrate from another Discord setup (e.g. hubdustry-go-mcp)')
+  .option('--from <adapter>', 'Source adapter id (run without --from to list)')
+  .option('--source <path>', 'Path to source repo (default: current dir)')
+  .option('--json', 'Output as JSON instead of TTY-friendly text')
+  .action(async (options: { from?: string; source?: string; json?: boolean }) => {
     const { migrateAction } = await import('./commands/migrate.js');
-    await migrateAction();
+    await migrateAction(options);
   });
 
 // Run the parser only when invoked as the bin script (not when imported

--- a/packages/mcp-server/src/commands/doctor.integration.test.ts
+++ b/packages/mcp-server/src/commands/doctor.integration.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Integration test: `doctorAction({ online: true, json: true })` against
+ * a real loopback HTTP server — Plan 9 Phase C.
+ *
+ * Why a real server (not msw):
+ *   - msw patches global `fetch` / ClientRequest at a layer that has
+ *     proven flaky in this repo's history (see otel-undici.integration
+ *     test for the same conclusion). For a check whose entire job is to
+ *     verify network reachability, swapping the network out wholesale
+ *     defeats the test's purpose.
+ *   - `node:http` listens on port 0 → the OS picks a free port → no
+ *     conflict with concurrent test runs.
+ *
+ * Two endpoints are mounted on the same server:
+ *   - GET /api/v10/users/@me  → mocks Discord (token-online)
+ *   - HEAD /v1/traces         → mocks OTLP collector (otel-reachable)
+ *
+ * Test-only env overrides used here:
+ *   - DISCORD_API_BASE_URL → swaps the Discord base URL inside
+ *     token-online.ts so we hit the loopback server. Documented in that
+ *     file's header as test-only.
+ *   - OTEL_EXPORTER_OTLP_ENDPOINT → standard config knob; we just point
+ *     it at the loopback server (this is its real production knob).
+ *
+ * The test asserts all 7 checks appear in the JSON output with their
+ * expected status — including the 5 offline ones — so a regression in
+ * any phase shows up here as a clear assertion failure.
+ */
+import { createServer, type Server as HttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let httpServer: HttpServer;
+let baseUrl: string;
+
+const VALID_TOKEN = `Bot ${'a'.repeat(60)}`;
+
+const originalDiscordApiBase = process.env.DISCORD_API_BASE_URL;
+const originalToken = process.env.DISCORD_TOKEN;
+const originalOtelEnabled = process.env.OTEL_ENABLED;
+const originalOtelEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+const originalExitCode = process.exitCode;
+
+let stdoutWrites: string[] = [];
+
+beforeAll(async () => {
+  httpServer = createServer((req, res) => {
+    // GET /api/v10/users/@me → 200 with bot identity.
+    if (req.method === 'GET' && req.url === '/api/v10/users/@me') {
+      // Surface the Authorization header back to the test if needed,
+      // but never log the actual token (defensive — matches the privacy
+      // contract). We just answer with a fixed bot identity.
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ id: '987654321098765432', username: 'doctor-bot', bot: true }));
+      return;
+    }
+    // HEAD /v1/traces → 200 (collector alive).
+    if (req.method === 'HEAD' && req.url === '/v1/traces') {
+      res.writeHead(200);
+      res.end();
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+  const addr = httpServer.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    httpServer.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+beforeEach(() => {
+  stdoutWrites = [];
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    stdoutWrites.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  // Point Discord at our loopback server.
+  process.env.DISCORD_API_BASE_URL = `${baseUrl}/api/v10`;
+  process.env.DISCORD_TOKEN = VALID_TOKEN;
+  process.env.OTEL_ENABLED = 'true';
+  process.env.OTEL_EXPORTER_OTLP_ENDPOINT = baseUrl;
+  process.exitCode = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalDiscordApiBase !== undefined) {
+    process.env.DISCORD_API_BASE_URL = originalDiscordApiBase;
+  } else {
+    delete process.env.DISCORD_API_BASE_URL;
+  }
+  if (originalToken !== undefined) {
+    process.env.DISCORD_TOKEN = originalToken;
+  } else {
+    delete process.env.DISCORD_TOKEN;
+  }
+  if (originalOtelEnabled !== undefined) {
+    process.env.OTEL_ENABLED = originalOtelEnabled;
+  } else {
+    delete process.env.OTEL_ENABLED;
+  }
+  if (originalOtelEndpoint !== undefined) {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = originalOtelEndpoint;
+  } else {
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  }
+  process.exitCode = originalExitCode;
+});
+
+function stdoutOutput(): string {
+  return stdoutWrites.join('');
+}
+
+describe('doctorAction online integration (Plan 9 Phase C)', () => {
+  it('runs all 7 checks against a live loopback server and reports JSON', async () => {
+    // NOTE: token-online.ts caches DISCORD_API_BASE at module-eval time. We
+    // import doctor here AFTER setting DISCORD_API_BASE_URL so the cached
+    // value picks up the loopback URL. vi.resetModules() ensures a fresh
+    // import even if a previous test already evaluated the module.
+    vi.resetModules();
+    const { doctorAction } = await import('./doctor.js');
+
+    await doctorAction({ json: true, online: true });
+
+    const out = stdoutOutput();
+    const parsed = JSON.parse(out) as {
+      ok: boolean;
+      exitCode: number;
+      summary: string;
+      data: { checks: Array<{ id: string; status: string; details?: Record<string, unknown> }> };
+    };
+
+    // 7 checks, in order.
+    const ids = parsed.data.checks.map((c) => c.id);
+    expect(ids).toEqual([
+      'node-version',
+      'token-format',
+      'env-vars',
+      'audit-sink',
+      'client-caps',
+      'token-online',
+      'otel-reachable',
+    ]);
+
+    // Online checks resolved against the live server.
+    const tokenOnline = parsed.data.checks.find((c) => c.id === 'token-online');
+    expect(tokenOnline?.status).toBe('ok');
+    expect(tokenOnline?.details?.username).toBe('doctor-bot');
+    expect(tokenOnline?.details?.id).toBe('987654321098765432');
+    expect(tokenOnline?.details?.bot).toBe(true);
+
+    const otelReachable = parsed.data.checks.find((c) => c.id === 'otel-reachable');
+    expect(otelReachable?.status).toBe('ok');
+    expect(otelReachable?.details?.endpoint).toBe(baseUrl);
+    expect(otelReachable?.details?.method).toBe('HEAD');
+
+    // Summary mentions 7.
+    expect(parsed.summary).toMatch(/^7 checks: /);
+  });
+
+  it('reports token-online fail when server returns 401 (token rejected)', async () => {
+    // Swap the request handler to answer 401 for /users/@me only on the
+    // next request, then restore. We do this by closing + relaunching a
+    // tiny override server isn't necessary — instead we set a one-shot
+    // response by toggling a flag the handler checks.
+    //
+    // Simpler approach: spin up a SECOND server for this test that always
+    // returns 401, point DISCORD_API_BASE_URL there, run doctor.
+    const failingServer = createServer((req, res) => {
+      if (req.method === 'GET' && req.url === '/api/v10/users/@me') {
+        res.writeHead(401);
+        res.end();
+        return;
+      }
+      if (req.method === 'HEAD' && req.url === '/v1/traces') {
+        res.writeHead(200);
+        res.end();
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((resolve) => failingServer.listen(0, '127.0.0.1', resolve));
+    const failingAddr = failingServer.address() as AddressInfo;
+    const failingUrl = `http://127.0.0.1:${failingAddr.port}`;
+
+    try {
+      process.env.DISCORD_API_BASE_URL = `${failingUrl}/api/v10`;
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT = failingUrl;
+
+      vi.resetModules();
+      const { doctorAction } = await import('./doctor.js');
+      await doctorAction({ json: true, online: true });
+
+      const parsed = JSON.parse(stdoutOutput()) as {
+        data: { checks: Array<{ id: string; status: string }> };
+      };
+      const tokenOnline = parsed.data.checks.find((c) => c.id === 'token-online');
+      expect(tokenOnline?.status).toBe('fail');
+      expect(process.exitCode).toBe(2);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        failingServer.close((err) => (err ? reject(err) : resolve())),
+      );
+    }
+  });
+});

--- a/packages/mcp-server/src/commands/doctor.test.ts
+++ b/packages/mcp-server/src/commands/doctor.test.ts
@@ -24,6 +24,11 @@ vi.mock('node:fs', async () => {
 
 const { doctorAction } = await import('./doctor.js');
 
+// Default fetch mock: any --online test that exercises the online checks
+// without explicitly stubbing fetch will see a network warn — fine for
+// the ID-set assertions that don't care about per-check status.
+const DEFAULT_FETCH_MOCK = () => vi.fn().mockResolvedValue(new Response('', { status: 500 }));
+
 const VALID_TOKEN = `Bot ${'a'.repeat(60)}`;
 
 const originalToken = process.env.DISCORD_TOKEN;
@@ -49,6 +54,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   accessSyncImpl = () => undefined;
   if (originalToken !== undefined) {
     process.env.DISCORD_TOKEN = originalToken;
@@ -92,27 +98,49 @@ function hasAnsi(s: string): boolean {
   return s.includes(CSI_BYTE);
 }
 
-describe('doctorAction — offline check selection', () => {
-  it('runs only offline checks when --online is absent', async () => {
+describe('doctorAction — online check selection', () => {
+  it('runs only the 5 offline checks when --online is absent', async () => {
     process.env.DISCORD_TOKEN = VALID_TOKEN;
+    const fetchMock = DEFAULT_FETCH_MOCK();
+    vi.stubGlobal('fetch', fetchMock);
     await doctorAction({ json: true });
     const parsed = JSON.parse(stdoutOutput()) as {
       data?: { checks?: Array<{ id: string }> };
     };
     const ids = parsed.data?.checks?.map((c) => c.id) ?? [];
-    // The 5 offline checks ship in Phase B. Phase C will add online ones.
     expect(ids).toEqual(['node-version', 'token-format', 'env-vars', 'audit-sink', 'client-caps']);
+    // CRITICAL: --online not passed → online checks must NOT call fetch.
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('runs the same set when --online is true (no online checks in Phase B)', async () => {
+  it('runs all 7 checks (5 offline + 2 online) when --online is true', async () => {
     process.env.DISCORD_TOKEN = VALID_TOKEN;
+    // OTEL_ENABLED defaults to false → otel-reachable skips its fetch.
+    // token-online still calls fetch — return a 200 so the test reports ok.
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: '1', username: 'bot', bot: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
     await doctorAction({ json: true, online: true });
     const parsed = JSON.parse(stdoutOutput()) as {
       data?: { checks?: Array<{ id: string }> };
     };
     const ids = parsed.data?.checks?.map((c) => c.id) ?? [];
-    // Phase B has zero online-tagged checks, so the set is identical.
-    expect(ids).toEqual(['node-version', 'token-format', 'env-vars', 'audit-sink', 'client-caps']);
+    expect(ids).toEqual([
+      'node-version',
+      'token-format',
+      'env-vars',
+      'audit-sink',
+      'client-caps',
+      'token-online',
+      'otel-reachable',
+    ]);
+    // token-online hit the network exactly once. otel-reachable did NOT
+    // because OTEL_ENABLED=false → skips request.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -208,10 +236,19 @@ describe('doctorAction — output formatting', () => {
     expect(parsed.summary).toMatch(/\d+ checks:/);
   });
 
-  it('summary string follows the "N checks: F fail, W warn, O ok" format', async () => {
+  it('summary string follows the "N checks: F fail, W warn, O ok" format (offline-only)', async () => {
     process.env.DISCORD_TOKEN = VALID_TOKEN;
     await doctorAction({ json: true });
     const parsed = JSON.parse(stdoutOutput());
+    // 5 offline checks when --online is absent.
     expect(parsed.summary).toMatch(/^5 checks: \d+ fail, \d+ warn, \d+ ok$/);
+  });
+
+  it('summary reports 7 checks when --online is true', async () => {
+    process.env.DISCORD_TOKEN = VALID_TOKEN;
+    vi.stubGlobal('fetch', DEFAULT_FETCH_MOCK());
+    await doctorAction({ json: true, online: true });
+    const parsed = JSON.parse(stdoutOutput());
+    expect(parsed.summary).toMatch(/^7 checks: \d+ fail, \d+ warn, \d+ ok$/);
   });
 });

--- a/packages/mcp-server/src/commands/doctor.test.ts
+++ b/packages/mcp-server/src/commands/doctor.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Integration-ish tests for `doctorAction` — Plan 9 Phase B.
+ *
+ * Covers the doctor command's aggregation logic, exit code mapping,
+ * and JSON / pretty-mode output. Per-check unit tests live alongside
+ * each check under `lib/checks/*.test.ts`. We mock `fs.accessSync`
+ * here only for the audit-sink scenarios — everything else uses real
+ * env-var manipulation against the real check implementations.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock node:fs at module-eval time so audit-sink (file branch) can be
+// driven deterministically. Default impl is a no-op (writable). Tests
+// that need a failing access rebind `accessSyncImpl` before calling.
+let accessSyncImpl: (...args: unknown[]) => void = () => undefined;
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    accessSync: ((...args: unknown[]) => accessSyncImpl(...args)) as typeof actual.accessSync,
+  };
+});
+
+const { doctorAction } = await import('./doctor.js');
+
+const VALID_TOKEN = `Bot ${'a'.repeat(60)}`;
+
+const originalToken = process.env.DISCORD_TOKEN;
+const originalAuditSink = process.env.MCP_AUDIT_SINK;
+const originalAuditFile = process.env.MCP_AUDIT_FILE;
+const originalIsTTY = process.stdout.isTTY;
+const originalExitCode = process.exitCode;
+
+let stdoutWrites: string[] = [];
+
+beforeEach(() => {
+  accessSyncImpl = () => undefined;
+  stdoutWrites = [];
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    stdoutWrites.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  delete process.env.DISCORD_TOKEN;
+  delete process.env.MCP_AUDIT_SINK;
+  delete process.env.MCP_AUDIT_FILE;
+  process.exitCode = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  accessSyncImpl = () => undefined;
+  if (originalToken !== undefined) {
+    process.env.DISCORD_TOKEN = originalToken;
+  } else {
+    delete process.env.DISCORD_TOKEN;
+  }
+  if (originalAuditSink !== undefined) {
+    process.env.MCP_AUDIT_SINK = originalAuditSink;
+  } else {
+    delete process.env.MCP_AUDIT_SINK;
+  }
+  if (originalAuditFile !== undefined) {
+    process.env.MCP_AUDIT_FILE = originalAuditFile;
+  } else {
+    delete process.env.MCP_AUDIT_FILE;
+  }
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value: originalIsTTY,
+    configurable: true,
+    writable: true,
+  });
+  process.exitCode = originalExitCode;
+});
+
+function setTTY(value: boolean): void {
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function stdoutOutput(): string {
+  return stdoutWrites.join('');
+}
+
+// CSI byte = ESC + '['. Avoid embedded control bytes in regex per
+// biome's noControlCharactersInRegex (mirrors output.test.ts).
+const CSI_BYTE = '\x1b[';
+function hasAnsi(s: string): boolean {
+  return s.includes(CSI_BYTE);
+}
+
+describe('doctorAction — offline check selection', () => {
+  it('runs only offline checks when --online is absent', async () => {
+    process.env.DISCORD_TOKEN = VALID_TOKEN;
+    await doctorAction({ json: true });
+    const parsed = JSON.parse(stdoutOutput()) as {
+      data?: { checks?: Array<{ id: string }> };
+    };
+    const ids = parsed.data?.checks?.map((c) => c.id) ?? [];
+    // The 5 offline checks ship in Phase B. Phase C will add online ones.
+    expect(ids).toEqual(['node-version', 'token-format', 'env-vars', 'audit-sink', 'client-caps']);
+  });
+
+  it('runs the same set when --online is true (no online checks in Phase B)', async () => {
+    process.env.DISCORD_TOKEN = VALID_TOKEN;
+    await doctorAction({ json: true, online: true });
+    const parsed = JSON.parse(stdoutOutput()) as {
+      data?: { checks?: Array<{ id: string }> };
+    };
+    const ids = parsed.data?.checks?.map((c) => c.id) ?? [];
+    // Phase B has zero online-tagged checks, so the set is identical.
+    expect(ids).toEqual(['node-version', 'token-format', 'env-vars', 'audit-sink', 'client-caps']);
+  });
+});
+
+describe('doctorAction — exit code mapping', () => {
+  it('returns exit code 2 when token-format fails', async () => {
+    // No DISCORD_TOKEN → token-format + env-vars both fail.
+    await doctorAction({ json: true });
+    expect(process.exitCode).toBe(2);
+    const parsed = JSON.parse(stdoutOutput());
+    expect(parsed.ok).toBe(false);
+    const tokenCheck = (parsed.data.checks as Array<{ id: string; status: string }>).find(
+      (c) => c.id === 'token-format',
+    );
+    expect(tokenCheck?.status).toBe('fail');
+  });
+
+  it('returns exit code 1 (warn) when only token-format warns and rest are ok', async () => {
+    // Valid shape but no "Bot " prefix → token-format warn.
+    process.env.DISCORD_TOKEN = 'a'.repeat(60);
+    await doctorAction({ json: true });
+    expect(process.exitCode).toBe(1);
+    const parsed = JSON.parse(stdoutOutput());
+    expect(parsed.exitCode).toBe(1);
+    expect(parsed.warnings).toBeDefined();
+    expect(parsed.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('returns exit code 0 when all checks pass', async () => {
+    process.env.DISCORD_TOKEN = VALID_TOKEN;
+    await doctorAction({ json: true });
+    expect(process.exitCode).toBe(0);
+    const parsed = JSON.parse(stdoutOutput());
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exitCode).toBe(0);
+  });
+});
+
+describe('doctorAction — audit-sink branches', () => {
+  it('reports audit-sink ok when stderr sink is selected', async () => {
+    process.env.DISCORD_TOKEN = VALID_TOKEN;
+    process.env.MCP_AUDIT_SINK = 'stderr';
+    await doctorAction({ json: true });
+    const parsed = JSON.parse(stdoutOutput());
+    const auditCheck = (parsed.data.checks as Array<{ id: string; status: string }>).find(
+      (c) => c.id === 'audit-sink',
+    );
+    expect(auditCheck?.status).toBe('ok');
+  });
+
+  it('reports audit-sink fail when file sink is unwritable', async () => {
+    process.env.DISCORD_TOKEN = VALID_TOKEN;
+    process.env.MCP_AUDIT_SINK = 'file';
+    process.env.MCP_AUDIT_FILE = '/nonexistent/no-perms/audit.jsonl';
+    accessSyncImpl = () => {
+      throw new Error('EACCES: permission denied');
+    };
+    await doctorAction({ json: true });
+    expect(process.exitCode).toBe(2);
+    const parsed = JSON.parse(stdoutOutput());
+    const auditCheck = (parsed.data.checks as Array<{ id: string; status: string }>).find(
+      (c) => c.id === 'audit-sink',
+    );
+    expect(auditCheck?.status).toBe('fail');
+  });
+});
+
+describe('doctorAction — output formatting', () => {
+  it('pretty mode includes ANSI color codes when stdout is a TTY', async () => {
+    setTTY(true);
+    process.env.DISCORD_TOKEN = VALID_TOKEN;
+    await doctorAction({ json: false });
+    const out = stdoutOutput();
+    expect(hasAnsi(out)).toBe(true);
+    expect(out).toContain('OK');
+  });
+
+  it('pretty mode without TTY omits ANSI codes', async () => {
+    setTTY(false);
+    process.env.DISCORD_TOKEN = VALID_TOKEN;
+    await doctorAction({ json: false });
+    const out = stdoutOutput();
+    expect(hasAnsi(out)).toBe(false);
+  });
+
+  it('json mode strips ANSI even on TTY and produces parseable output', async () => {
+    setTTY(true);
+    process.env.DISCORD_TOKEN = VALID_TOKEN;
+    await doctorAction({ json: true });
+    const out = stdoutOutput();
+    expect(hasAnsi(out)).toBe(false);
+    expect(() => JSON.parse(out)).not.toThrow();
+    const parsed = JSON.parse(out);
+    expect(parsed.summary).toMatch(/\d+ checks:/);
+  });
+
+  it('summary string follows the "N checks: F fail, W warn, O ok" format', async () => {
+    process.env.DISCORD_TOKEN = VALID_TOKEN;
+    await doctorAction({ json: true });
+    const parsed = JSON.parse(stdoutOutput());
+    expect(parsed.summary).toMatch(/^5 checks: \d+ fail, \d+ warn, \d+ ok$/);
+  });
+});

--- a/packages/mcp-server/src/commands/doctor.ts
+++ b/packages/mcp-server/src/commands/doctor.ts
@@ -1,0 +1,17 @@
+/**
+ * `discord-mcp doctor` — placeholder for Plan 9 Phase B.
+ *
+ * Phase A wires up the sub-command surface so the option shape
+ * (--json / --online) is stable. Phase B will implement the
+ * actual offline + online checks (env, token, REST handshake,
+ * gateway readiness) and emit a CommandResult via emitResult().
+ */
+export interface DoctorOptions {
+  json?: boolean;
+  online?: boolean;
+}
+
+export async function doctorAction(_options: DoctorOptions): Promise<void> {
+  process.stdout.write('discord-mcp doctor: not yet implemented (Plan 9 Phase B)\n');
+  process.exitCode = 2;
+}

--- a/packages/mcp-server/src/commands/doctor.ts
+++ b/packages/mcp-server/src/commands/doctor.ts
@@ -1,17 +1,88 @@
 /**
- * `discord-mcp doctor` — placeholder for Plan 9 Phase B.
+ * `discord-mcp doctor` — Plan 9 Phase B.
  *
- * Phase A wires up the sub-command surface so the option shape
- * (--json / --online) is stable. Phase B will implement the
- * actual offline + online checks (env, token, REST handshake,
- * gateway readiness) and emit a CommandResult via emitResult().
+ * Replaces the Phase A placeholder. Iterates the registered offline
+ * checks (Phase C will add online ones) and aggregates their results
+ * into a single CommandResult.
+ *
+ * Exit code mapping (per emitResult contract):
+ *   - 0 → all checks ok
+ *   - 1 → at least one warn, no fails
+ *   - 2 → at least one fail
+ *
+ * `--online` flag is wired but only filters checks (online-tagged ones
+ * are skipped when false). The actual online checks are introduced in
+ * Phase C — for now the flag is a no-op gating mechanism, kept here so
+ * Phase A's option shape stays stable.
+ *
+ * Config parse: we attempt `loadConfig(process.env)` once and pass the
+ * resolved `Config | null` to each check's `run()`. Checks that need
+ * raw env (e.g. token-format) read `process.env` directly so they
+ * still report meaningful results when Config rejected the env. The
+ * `env-vars` check is the canonical reporter for the parse failure
+ * itself (status=fail with zod issue details).
  */
+import { type Config, loadConfig } from '@discord-mcp/core';
+import { ALL_CHECKS, type CheckResult } from '../lib/checks/index.js';
+import { emitResult } from '../lib/output.js';
+
 export interface DoctorOptions {
   json?: boolean;
   online?: boolean;
 }
 
-export async function doctorAction(_options: DoctorOptions): Promise<void> {
-  process.stdout.write('discord-mcp doctor: not yet implemented (Plan 9 Phase B)\n');
-  process.exitCode = 2;
+export async function doctorAction(opts: DoctorOptions): Promise<void> {
+  // Filter: when --online is omitted/false, run only offline checks.
+  // When --online is true, run everything (offline + online).
+  const checks = ALL_CHECKS.filter((c) => opts.online === true || c.online === false);
+
+  let cfg: Config | null = null;
+  try {
+    cfg = loadConfig(process.env);
+  } catch {
+    // env-vars check is the canonical reporter — leave cfg as null and
+    // let each check decide what to do (most fall back to raw env).
+    cfg = null;
+  }
+
+  const results: CheckResult[] = [];
+  for (const check of checks) {
+    try {
+      results.push(await check.run(cfg));
+    } catch (e) {
+      // Defensive: a check throwing is a bug, not user error. Surface it
+      // as a fail so the run is reproducible from the JSON output.
+      results.push({
+        id: check.id,
+        status: 'fail',
+        message: `check threw: ${e instanceof Error ? e.message : String(e)}`,
+      });
+    }
+  }
+
+  const fails = results.filter((r) => r.status === 'fail').length;
+  const warns = results.filter((r) => r.status === 'warn').length;
+  const oks = results.length - fails - warns;
+  const exitCode: 0 | 1 | 2 = fails > 0 ? 2 : warns > 0 ? 1 : 0;
+
+  // Pretty-mode detail lines: one bullet per check with status + id +
+  // first-line of message. JSON consumers see the full structured array
+  // under `data.checks`.
+  const detailLines = results.map((r) => {
+    const tag = r.status === 'ok' ? 'OK  ' : r.status === 'warn' ? 'WARN' : 'FAIL';
+    return `[${tag}] ${r.id}: ${r.message}`;
+  });
+
+  emitResult(
+    {
+      ok: fails === 0,
+      exitCode,
+      summary: `${results.length} checks: ${fails} fail, ${warns} warn, ${oks} ok`,
+      details: detailLines,
+      warnings: results.filter((r) => r.status === 'warn').map((r) => `[${r.id}] ${r.message}`),
+      errors: results.filter((r) => r.status === 'fail').map((r) => `[${r.id}] ${r.message}`),
+      data: { checks: results as unknown as Record<string, unknown>[] },
+    },
+    opts.json === true,
+  );
 }

--- a/packages/mcp-server/src/commands/init.test.ts
+++ b/packages/mcp-server/src/commands/init.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Integration-ish tests for `initAction` — Plan 9 Phase D.
+ *
+ * The non-interactive paths are exercised here. Interactive prompts
+ * are tested in `lib/prompt.test.ts` against mocked readline; this
+ * file forces non-interactive (TTY=false) so the action follows the
+ * deterministic flag-only branch.
+ *
+ * `node:fs` is partially mocked: `existsSync` and `writeFileSync` are
+ * driven per-test via small in-memory shims so we don't need real
+ * temp files. Read paths still hit the real fs (none used here).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mocked fs — set per-test by reassigning the impl variables. Default
+// is a clean filesystem (existsSync → false, writeFileSync → no-op).
+let existsImpl: (path: string) => boolean = () => false;
+let writeImpl: (path: string, data: string) => void = () => undefined;
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    existsSync: ((p: string) => existsImpl(p)) as typeof actual.existsSync,
+    writeFileSync: ((p: string, data: string) => writeImpl(p, data)) as typeof actual.writeFileSync,
+  };
+});
+
+const { initAction } = await import('./init.js');
+
+const originalStdinTTY = process.stdin.isTTY;
+const originalStdoutTTY = process.stdout.isTTY;
+const originalExitCode = process.exitCode;
+
+let stdoutWrites: string[] = [];
+
+beforeEach(() => {
+  existsImpl = () => false;
+  writeImpl = () => undefined;
+  stdoutWrites = [];
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    stdoutWrites.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  // Force non-interactive so the action takes the flag-only branch.
+  Object.defineProperty(process.stdin, 'isTTY', {
+    value: false,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value: false,
+    configurable: true,
+    writable: true,
+  });
+  process.exitCode = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process.stdin, 'isTTY', {
+    value: originalStdinTTY,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value: originalStdoutTTY,
+    configurable: true,
+    writable: true,
+  });
+  process.exitCode = originalExitCode;
+});
+
+function stdoutOutput(): string {
+  return stdoutWrites.join('');
+}
+
+interface InitJsonResult {
+  ok: boolean;
+  exitCode: number;
+  summary: string;
+  data?: {
+    client?: string;
+    configFilePath?: string;
+    content?: string;
+    instructions?: string;
+    gateway?: boolean;
+  };
+}
+
+interface ParsedSnippet {
+  mcpServers: {
+    'discord-mcp': {
+      command: string;
+      args: string[];
+      env: Record<string, string>;
+    };
+  };
+}
+
+describe('initAction — non-interactive defaults', () => {
+  it('with no flags defaults to client=generic and the env-var token placeholder', async () => {
+    await initAction({ json: true });
+    expect(process.exitCode).toBe(0);
+    const parsed = JSON.parse(stdoutOutput()) as InitJsonResult;
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data?.client).toBe('generic');
+    const snippet = JSON.parse(parsed.data?.content ?? '{}') as ParsedSnippet;
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder, not JS interpolation
+    expect(snippet.mcpServers['discord-mcp'].env.DISCORD_TOKEN).toBe('${env:DISCORD_TOKEN}');
+    expect(parsed.data?.gateway).toBe(false);
+  });
+
+  it('summary mentions the displayName when generated to stdout', async () => {
+    await initAction({ json: true });
+    const parsed = JSON.parse(stdoutOutput()) as InitJsonResult;
+    expect(parsed.summary).toContain('Generic MCP client');
+  });
+});
+
+describe('initAction — explicit flags', () => {
+  it('with --client claude-desktop --token "Bot abc..." produces matching snippet', async () => {
+    await initAction({ json: true, client: 'claude-desktop', token: 'Bot abc123' });
+    const parsed = JSON.parse(stdoutOutput()) as InitJsonResult;
+    expect(parsed.data?.client).toBe('claude-desktop');
+    const snippet = JSON.parse(parsed.data?.content ?? '{}') as ParsedSnippet;
+    expect(snippet.mcpServers['discord-mcp'].env.DISCORD_TOKEN).toBe('Bot abc123');
+  });
+
+  it('with --client claude-code adopts that generator', async () => {
+    await initAction({ json: true, client: 'claude-code', token: 'Bot xyz' });
+    const parsed = JSON.parse(stdoutOutput()) as InitJsonResult;
+    expect(parsed.data?.client).toBe('claude-code');
+    expect(parsed.data?.configFilePath).toContain('.claude.json');
+  });
+
+  it('with --client cursor adopts that generator', async () => {
+    await initAction({ json: true, client: 'cursor', token: 'Bot xyz' });
+    const parsed = JSON.parse(stdoutOutput()) as InitJsonResult;
+    expect(parsed.data?.client).toBe('cursor');
+    expect(parsed.data?.configFilePath).toContain('.cursor/mcp.json');
+  });
+
+  it('with --gateway appends --gateway to args in the snippet', async () => {
+    await initAction({ json: true, client: 'generic', gateway: true });
+    const parsed = JSON.parse(stdoutOutput()) as InitJsonResult;
+    const snippet = JSON.parse(parsed.data?.content ?? '{}') as ParsedSnippet;
+    expect(snippet.mcpServers['discord-mcp'].args).toContain('--gateway');
+    expect(parsed.data?.gateway).toBe(true);
+  });
+
+  it('without --gateway omits the flag from args', async () => {
+    await initAction({ json: true, client: 'generic' });
+    const parsed = JSON.parse(stdoutOutput()) as InitJsonResult;
+    const snippet = JSON.parse(parsed.data?.content ?? '{}') as ParsedSnippet;
+    expect(snippet.mcpServers['discord-mcp'].args).not.toContain('--gateway');
+  });
+
+  it('with empty --token "" collapses to the env-var placeholder', async () => {
+    await initAction({ json: true, client: 'generic', token: '' });
+    const parsed = JSON.parse(stdoutOutput()) as InitJsonResult;
+    const snippet = JSON.parse(parsed.data?.content ?? '{}') as ParsedSnippet;
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder
+    expect(snippet.mcpServers['discord-mcp'].env.DISCORD_TOKEN).toBe('${env:DISCORD_TOKEN}');
+  });
+});
+
+describe('initAction — unknown client', () => {
+  it('exits with code 2 and lists the available clients', async () => {
+    await initAction({ json: true, client: 'no-such-client' });
+    expect(process.exitCode).toBe(2);
+    const parsed = JSON.parse(stdoutOutput()) as InitJsonResult & {
+      errors?: string[];
+    };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.summary).toContain('no-such-client');
+    expect(parsed.errors?.[0]).toContain('claude-desktop');
+    expect(parsed.errors?.[0]).toContain('generic');
+  });
+});
+
+describe('initAction — --output file writing', () => {
+  it('writes the snippet to --output and reports the path', async () => {
+    let writtenPath: string | undefined;
+    let writtenData: string | undefined;
+    writeImpl = (p, d) => {
+      writtenPath = p;
+      writtenData = d;
+    };
+
+    await initAction({
+      json: true,
+      client: 'claude-desktop',
+      token: 'Bot abc',
+      output: 'C:/tmp/out.json',
+    });
+    expect(process.exitCode).toBe(0);
+    expect(writtenPath).toBe('C:/tmp/out.json');
+    expect(writtenData).toBeDefined();
+    // The written content is parseable JSON.
+    expect(() => JSON.parse(writtenData ?? '')).not.toThrow();
+    const parsed = JSON.parse(stdoutOutput()) as InitJsonResult;
+    expect(parsed.summary).toContain('C:/tmp/out.json');
+  });
+
+  it('refuses to overwrite an existing --output path without --force', async () => {
+    existsImpl = () => true;
+    let writeCalled = false;
+    writeImpl = () => {
+      writeCalled = true;
+    };
+
+    await initAction({
+      json: true,
+      client: 'generic',
+      output: 'C:/tmp/exists.json',
+    });
+    expect(process.exitCode).toBe(2);
+    expect(writeCalled).toBe(false);
+    const parsed = JSON.parse(stdoutOutput()) as InitJsonResult;
+    expect(parsed.ok).toBe(false);
+    expect(parsed.summary).toContain('--force');
+  });
+
+  it('overwrites an existing --output path when --force is set', async () => {
+    existsImpl = () => true;
+    let writeCalled = false;
+    writeImpl = () => {
+      writeCalled = true;
+    };
+
+    await initAction({
+      json: true,
+      client: 'generic',
+      output: 'C:/tmp/exists.json',
+      force: true,
+    });
+    expect(process.exitCode).toBe(0);
+    expect(writeCalled).toBe(true);
+  });
+});
+
+describe('initAction — output formatting', () => {
+  it('--json mode produces parseable structured output', async () => {
+    await initAction({ json: true, client: 'generic' });
+    expect(() => JSON.parse(stdoutOutput())).not.toThrow();
+    const parsed = JSON.parse(stdoutOutput()) as InitJsonResult;
+    expect(parsed.data?.content).toBeDefined();
+    expect(parsed.data?.instructions).toBeDefined();
+    expect(parsed.data?.configFilePath).toBeDefined();
+  });
+
+  it('pretty mode includes the snippet content under details when no --output', async () => {
+    await initAction({ json: false, client: 'generic' });
+    const out = stdoutOutput();
+    expect(out).toContain('Snippet:');
+    expect(out).toContain('mcpServers');
+    expect(out).toContain('discord-mcp');
+  });
+
+  it('pretty mode omits the inline snippet body when --output is used', async () => {
+    writeImpl = () => undefined;
+    await initAction({ json: false, client: 'generic', output: 'C:/tmp/out.json' });
+    const out = stdoutOutput();
+    expect(out).toContain('wrote');
+    expect(out).toContain('C:/tmp/out.json');
+    // No "Snippet:" inline block when written to file.
+    expect(out).not.toContain('Snippet:');
+  });
+});

--- a/packages/mcp-server/src/commands/init.ts
+++ b/packages/mcp-server/src/commands/init.ts
@@ -1,11 +1,204 @@
 /**
- * `discord-mcp init` — placeholder for Plan 9 Phase C.
+ * `discord-mcp init` — Plan 9 Phase D.
  *
- * Phase A wires up the sub-command surface. Phase C will scaffold
- * mcp.json + .env from interactive prompts (no `inquirer` dep —
- * we'll roll a tiny readline helper to keep the zero-deps rule).
+ * Replaces the Phase A placeholder. Bootstraps an MCP client config
+ * snippet that the user can paste into their client's config file (or
+ * have us write directly via `--output`).
+ *
+ * Flow:
+ *   1. Resolve which client (`--client <id>` OR interactive choice OR
+ *      'generic' as the silent default for non-interactive runs).
+ *   2. Resolve the Discord token (`--token` OR interactive prompt OR
+ *      `${env:DISCORD_TOKEN}` placeholder so users don't accidentally
+ *      bake a real secret into a committed file).
+ *   3. Resolve the gateway flag (`--gateway` OR interactive yes/no OR
+ *      false by default).
+ *   4. Pick a serverPath/serverArgs strategy. We use the current Node
+ *      binary + the resolved CLI script — works for any installation
+ *      (workspace, global npm, npx) at the cost of an absolute path
+ *      that may need editing if the user later moves the project.
+ *      The output explicitly tells the user how to switch to
+ *      `npx @discord-mcp/cli` for portable distribution.
+ *   5. Generate the snippet via the chosen ClientGenerator.
+ *   6. Either write to `--output <path>` (with `--force` for overwrite
+ *      protection) or print to stdout / structured payload.
+ *
+ * Token redaction: in pretty mode the snippet text contains whatever
+ * `--token` was passed — including raw secrets. The CLI flag's help
+ * text warns about this. The placeholder default avoids the issue
+ * entirely. We do NOT echo the token in any other log line.
  */
-export async function initAction(): Promise<void> {
-  process.stdout.write('discord-mcp init: not yet implemented (Plan 9 Phase C)\n');
-  process.exitCode = 2;
+import { existsSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { ALL_GENERATORS } from '../lib/client-snippets/index.js';
+import { emitResult } from '../lib/output.js';
+import { ask, askChoice, askYesNo, isInteractive } from '../lib/prompt.js';
+
+export interface InitOptions {
+  token?: string;
+  client?: string;
+  output?: string;
+  force?: boolean;
+  gateway?: boolean;
+  json?: boolean;
+}
+
+// Literal placeholder string used when the user opts out of supplying a
+// real token. Clients that support env-var interpolation (Claude Desktop,
+// Cursor, etc.) will resolve this at startup; clients that don't will
+// flag it as a missing token so the user notices.
+//
+// biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder for MCP client env interpolation
+const TOKEN_PLACEHOLDER = '${env:DISCORD_TOKEN}';
+
+/**
+ * Resolve the absolute path to the running CLI script. Used as the
+ * second `serverArgs` element when emitting `node <cli.js>`.
+ *
+ * Uses `import.meta.url` (Node 20+ ESM-stable) via `fileURLToPath`.
+ * `import.meta.dirname` would be slightly cleaner but tsdown's bundle
+ * output may reshape directory layout; resolving via URL is portable
+ * across both source-mode (vitest) and bundled-mode (production).
+ */
+function resolveCliPath(): string {
+  // import.meta.url points to the running .js file (or .ts under vitest).
+  // For source mode we want the cli.js sibling to commands/; the user
+  // will manually adjust if they install via npx.
+  const here = fileURLToPath(new URL('.', import.meta.url));
+  // commands/init.js → ../cli.js
+  return new URL('../cli.js', `file://${here}/`).pathname;
+}
+
+export async function initAction(opts: InitOptions): Promise<void> {
+  const asJson = opts.json === true;
+
+  // 1. Resolve client.
+  let clientId = opts.client;
+  if (clientId === undefined) {
+    if (isInteractive()) {
+      clientId = await askChoice(
+        'Which MCP client?',
+        ALL_GENERATORS.map((g) => g.id),
+        0,
+      );
+    } else {
+      clientId = 'generic';
+    }
+  }
+  const generator = ALL_GENERATORS.find((g) => g.id === clientId);
+  if (!generator) {
+    emitResult(
+      {
+        ok: false,
+        exitCode: 2,
+        summary: `unknown client: ${clientId}`,
+        errors: [`Available clients: ${ALL_GENERATORS.map((g) => g.id).join(', ')}`],
+      },
+      asJson,
+    );
+    return;
+  }
+
+  // 2. Resolve token. The empty/placeholder branches collapse to the
+  //    explicit env-var-interpolation placeholder.
+  let token = opts.token;
+  if (token === undefined) {
+    if (isInteractive()) {
+      token = await ask(
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder shown to the user
+        'Discord bot token (leave empty for ${env:DISCORD_TOKEN} placeholder)',
+        TOKEN_PLACEHOLDER,
+      );
+    } else {
+      token = TOKEN_PLACEHOLDER;
+    }
+  }
+  if (token === '' || token === TOKEN_PLACEHOLDER) {
+    token = TOKEN_PLACEHOLDER;
+  }
+
+  // 3. Resolve gateway flag.
+  let gateway = opts.gateway;
+  if (gateway === undefined) {
+    if (isInteractive()) {
+      gateway = await askYesNo('Enable Discord Gateway resource subscriptions?', false);
+    } else {
+      gateway = false;
+    }
+  }
+
+  // 4. Resolve server path. We default to `node <abs cli.js>` because
+  //    this works for every install (workspace, global, npx-cached) at
+  //    the cost of being installation-specific.
+  const serverPath = process.execPath;
+  const serverArgs: string[] = [resolveCliPath()];
+
+  // 5. Generate snippet.
+  const snippet = generator.generate({
+    serverPath,
+    serverArgs,
+    discordToken: token,
+    gateway,
+  });
+
+  // 6. Write or print.
+  let writtenTo: string | undefined;
+  if (opts.output !== undefined) {
+    if (existsSync(opts.output) && opts.force !== true) {
+      emitResult(
+        {
+          ok: false,
+          exitCode: 2,
+          summary: `${opts.output} exists; use --force to overwrite`,
+        },
+        asJson,
+      );
+      return;
+    }
+    writeFileSync(opts.output, snippet.content, 'utf8');
+    writtenTo = opts.output;
+  }
+
+  const portabilityNote =
+    'Adjust the `command` field if you install discord-mcp globally (e.g. set command="npx" args=["@discord-mcp/cli"]).';
+
+  emitResult(
+    {
+      ok: true,
+      exitCode: 0,
+      summary:
+        writtenTo !== undefined
+          ? `wrote ${generator.displayName} config to ${writtenTo}`
+          : `generated ${generator.displayName} config (use --output <path> to write to a file)`,
+      data: {
+        client: generator.id,
+        configFilePath: snippet.configFilePath,
+        content: snippet.content,
+        instructions: snippet.instructions,
+        gateway,
+      },
+      details:
+        writtenTo !== undefined
+          ? [
+              snippet.instructions,
+              '',
+              `Suggested config path:`,
+              snippet.configFilePath,
+              '',
+              portabilityNote,
+            ]
+          : [
+              snippet.instructions,
+              '',
+              `Suggested config path:`,
+              snippet.configFilePath,
+              '',
+              portabilityNote,
+              '',
+              'Snippet:',
+              snippet.content.trimEnd(),
+            ],
+    },
+    asJson,
+  );
 }

--- a/packages/mcp-server/src/commands/init.ts
+++ b/packages/mcp-server/src/commands/init.ts
@@ -1,0 +1,11 @@
+/**
+ * `discord-mcp init` — placeholder for Plan 9 Phase C.
+ *
+ * Phase A wires up the sub-command surface. Phase C will scaffold
+ * mcp.json + .env from interactive prompts (no `inquirer` dep —
+ * we'll roll a tiny readline helper to keep the zero-deps rule).
+ */
+export async function initAction(): Promise<void> {
+  process.stdout.write('discord-mcp init: not yet implemented (Plan 9 Phase C)\n');
+  process.exitCode = 2;
+}

--- a/packages/mcp-server/src/commands/migrate.test.ts
+++ b/packages/mcp-server/src/commands/migrate.test.ts
@@ -1,0 +1,169 @@
+/**
+ * `migrateAction` unit tests — Plan 9 Phase E.
+ *
+ * Drives the command directly (no commander). Captures stdout via a
+ * vi.spyOn write hook so tests can assert pretty-mode strings and
+ * parse JSON-mode payloads. Uses the synthetic Hubdustry fixture for
+ * the happy-path "ran with unmapped" assertion.
+ *
+ * cwd is mutated for the "no --source" branch — restored in afterEach.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { migrateAction } from './migrate.js';
+
+const PACKAGE_ROOT = fileURLToPath(new URL('../../', import.meta.url));
+const FIXTURE_ROOT = join(PACKAGE_ROOT, 'test-fixtures', 'hubdustry-go-mcp');
+
+const originalExitCode = process.exitCode;
+const originalCwd = process.cwd();
+
+let stdoutWrites: string[] = [];
+
+beforeEach(() => {
+  stdoutWrites = [];
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    stdoutWrites.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+  process.exitCode = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.exitCode = originalExitCode;
+  // Restore cwd in case a test changed it.
+  if (process.cwd() !== originalCwd) {
+    process.chdir(originalCwd);
+  }
+});
+
+function stdoutOutput(): string {
+  return stdoutWrites.join('');
+}
+
+interface MigrateJsonResult {
+  ok: boolean;
+  exitCode: number;
+  summary: string;
+  data?: {
+    available?: { id: string; description: string }[] | string[];
+    requested?: string;
+    adapter?: string;
+    sourcePath?: string;
+    result?: {
+      source: string;
+      sourcePath: string;
+      mappedTools: { original: string; mapped: string; confidence: string }[];
+      unmappedTools: string[];
+      manualReview: { original: string; reason: string }[];
+      warnings: string[];
+    };
+  };
+  errors?: string[];
+}
+
+describe('migrateAction — no --from', () => {
+  it('exits 2 and lists available adapters in JSON', async () => {
+    await migrateAction({ json: true });
+    expect(process.exitCode).toBe(2);
+    const parsed = JSON.parse(stdoutOutput()) as MigrateJsonResult;
+    expect(parsed.ok).toBe(false);
+    expect(parsed.summary).toContain('--from');
+    const available = parsed.data?.available as { id: string; description: string }[];
+    expect(Array.isArray(available)).toBe(true);
+    expect(available.some((a) => a.id === 'hubdustry-go-mcp')).toBe(true);
+  });
+
+  it('pretty mode prints available adapter ids', async () => {
+    await migrateAction({});
+    expect(process.exitCode).toBe(2);
+    const out = stdoutOutput();
+    expect(out).toContain('Available adapters');
+    expect(out).toContain('hubdustry-go-mcp');
+  });
+});
+
+describe('migrateAction — unknown --from', () => {
+  it('exits 2 with the requested id and the available list', async () => {
+    await migrateAction({ json: true, from: 'no-such-adapter' });
+    expect(process.exitCode).toBe(2);
+    const parsed = JSON.parse(stdoutOutput()) as MigrateJsonResult;
+    expect(parsed.summary).toContain('no-such-adapter');
+    expect(parsed.data?.requested).toBe('no-such-adapter');
+    expect(parsed.data?.available).toContain('hubdustry-go-mcp');
+  });
+});
+
+describe('migrateAction — source not detected', () => {
+  it('exits 2 when the source path has no Hubdustry markers', async () => {
+    const empty = mkdtempSync(join(tmpdir(), 'migrate-no-source-'));
+    try {
+      await migrateAction({ json: true, from: 'hubdustry-go-mcp', source: empty });
+      expect(process.exitCode).toBe(2);
+      const parsed = JSON.parse(stdoutOutput()) as MigrateJsonResult;
+      expect(parsed.summary).toContain('source not detected');
+      expect(parsed.data?.adapter).toBe('hubdustry-go-mcp');
+      expect(parsed.data?.sourcePath).toBe(empty);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to process.cwd() when --source is omitted', async () => {
+    // Move cwd somewhere with no Hubdustry markers, run with no --source.
+    // The result should mention that cwd as the sourcePath in the error.
+    const empty = mkdtempSync(join(tmpdir(), 'migrate-cwd-'));
+    process.chdir(empty);
+    try {
+      await migrateAction({ json: true, from: 'hubdustry-go-mcp' });
+      expect(process.exitCode).toBe(2);
+      const parsed = JSON.parse(stdoutOutput()) as MigrateJsonResult;
+      expect(parsed.summary).toContain('source not detected');
+    } finally {
+      // afterEach restores cwd before rmSync would conflict.
+      process.chdir(originalCwd);
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('migrateAction — Hubdustry fixture run', () => {
+  it('exits 1 (unmapped) and surfaces the 5 fixture tools', async () => {
+    await migrateAction({ json: true, from: 'hubdustry-go-mcp', source: FIXTURE_ROOT });
+    expect(process.exitCode).toBe(1);
+    const parsed = JSON.parse(stdoutOutput()) as MigrateJsonResult;
+    expect(parsed.ok).toBe(false);
+    expect(parsed.exitCode).toBe(1);
+    expect(parsed.summary).toContain('0/5 mapped');
+    expect(parsed.summary).toContain('5 unmapped');
+    const result = parsed.data?.result;
+    expect(result?.unmappedTools.length).toBe(5);
+    expect(result?.mappedTools.length).toBe(0);
+    expect(result?.manualReview.length).toBe(0);
+  });
+
+  it('pretty mode lists the unmapped tool names under "Unmapped"', async () => {
+    await migrateAction({ json: false, from: 'hubdustry-go-mcp', source: FIXTURE_ROOT });
+    expect(process.exitCode).toBe(1);
+    const out = stdoutOutput();
+    expect(out).toContain('Unmapped (5)');
+    expect(out).toContain('server.files.list');
+    expect(out).toContain('server.deploy.trigger');
+  });
+});
+
+describe('migrateAction — JSON output is parseable', () => {
+  it('every code path produces valid JSON when --json is set', async () => {
+    // Each branch parses cleanly.
+    await migrateAction({ json: true });
+    expect(() => JSON.parse(stdoutOutput())).not.toThrow();
+
+    stdoutWrites = [];
+    await migrateAction({ json: true, from: 'hubdustry-go-mcp', source: FIXTURE_ROOT });
+    expect(() => JSON.parse(stdoutOutput())).not.toThrow();
+  });
+});

--- a/packages/mcp-server/src/commands/migrate.ts
+++ b/packages/mcp-server/src/commands/migrate.ts
@@ -1,11 +1,128 @@
 /**
- * `discord-mcp migrate` — placeholder for Plan 9 Phase D.
+ * `discord-mcp migrate` — Plan 9 Phase E.
  *
- * Phase A wires up the sub-command surface. Phase D will diff
- * legacy mcp.json shapes against the current schema and rewrite
- * in place (with a .bak fallback).
+ * Replaces the Phase A placeholder. Drives the
+ * {@link MigrationSource} registry: pick an adapter via `--from`,
+ * detect it against `--source` (or cwd), and emit the resulting
+ * {@link MigrationResult} via the shared {@link emitResult} surface.
+ *
+ * Exit code policy (per plan §E.6):
+ *   - `0` — adapter ran AND every source tool was mapped (i.e.
+ *     unmappedTools.length === 0 && manualReview.length === 0).
+ *   - `1` — adapter ran but produced unmapped or manual-review items.
+ *     This is a "successful run with work left" — the user is told to
+ *     hand-edit the output, not that the migration failed.
+ *   - `2` — couldn't run at all: missing/unknown `--from`, source not
+ *     detected, IO failures inside the adapter.
+ *
+ * The command never imports adapter implementations directly; it only
+ * reads {@link ALL_ADAPTERS}. New sources land via Plan 11 by adding
+ * entries to the registry.
  */
-export async function migrateAction(): Promise<void> {
-  process.stdout.write('discord-mcp migrate: not yet implemented (Plan 9 Phase D)\n');
-  process.exitCode = 2;
+import { ALL_ADAPTERS } from '../lib/migrate-adapters/index.js';
+import { emitResult } from '../lib/output.js';
+
+export interface MigrateOptions {
+  from?: string;
+  source?: string;
+  json?: boolean;
+}
+
+export async function migrateAction(opts: MigrateOptions = {}): Promise<void> {
+  const asJson = opts.json === true;
+
+  // 1. No `--from` → list available adapters and exit 2.
+  if (opts.from === undefined) {
+    emitResult(
+      {
+        ok: false,
+        exitCode: 2,
+        summary: '--from <adapter-id> required',
+        data: {
+          available: ALL_ADAPTERS.map((a) => ({
+            id: a.id,
+            description: a.description,
+          })),
+        },
+        details: [
+          'Available adapters:',
+          ...ALL_ADAPTERS.map((a) => `  ${a.id} — ${a.description}`),
+        ],
+        errors: ['use --from with one of the IDs above'],
+      },
+      asJson,
+    );
+    return;
+  }
+
+  // 2. Resolve the adapter. Unknown id → exit 2 with the available list.
+  const adapter = ALL_ADAPTERS.find((a) => a.id === opts.from);
+  if (adapter === undefined) {
+    emitResult(
+      {
+        ok: false,
+        exitCode: 2,
+        summary: `unknown adapter: ${opts.from}`,
+        data: {
+          requested: opts.from,
+          available: ALL_ADAPTERS.map((a) => a.id),
+        },
+        errors: [`use --from with one of: ${ALL_ADAPTERS.map((a) => a.id).join(', ')}`],
+      },
+      asJson,
+    );
+    return;
+  }
+
+  // 3. Resolve the source path (default to cwd) and run detect().
+  //    `detect` MUST NOT throw per the adapter contract, so we don't
+  //    wrap this — any throw is an honest internal bug worth surfacing.
+  const sourcePath = opts.source ?? process.cwd();
+  if (!(await adapter.detect(sourcePath))) {
+    emitResult(
+      {
+        ok: false,
+        exitCode: 2,
+        summary: `source not detected at ${sourcePath}`,
+        data: { adapter: adapter.id, sourcePath },
+        errors: [
+          `adapter ${adapter.id} did not match the source — check --source path`,
+          `looked for adapter-specific markers in ${sourcePath}`,
+        ],
+      },
+      asJson,
+    );
+    return;
+  }
+
+  // 4. Run the adapter and report the result.
+  const result = await adapter.migrate(sourcePath);
+  const total =
+    result.mappedTools.length + result.unmappedTools.length + result.manualReview.length;
+
+  // Exit code: 0 only when every tool mapped cleanly. Unmapped or manual
+  // review still counts as "ran successfully with work left" → exit 1.
+  const exitCode: 0 | 1 | 2 =
+    result.unmappedTools.length === 0 && result.manualReview.length === 0 ? 0 : 1;
+
+  emitResult(
+    {
+      ok: exitCode === 0,
+      exitCode,
+      summary: `${result.mappedTools.length}/${total} mapped, ${result.unmappedTools.length} unmapped, ${result.manualReview.length} manual review`,
+      data: { result },
+      details: [
+        `Adapter: ${result.source}`,
+        `Source path: ${result.sourcePath}`,
+        `Mapped (${result.mappedTools.length}):`,
+        ...result.mappedTools.map((m) => `  ${m.original} → ${m.mapped} [${m.confidence}]`),
+        `Unmapped (${result.unmappedTools.length}):`,
+        ...result.unmappedTools.map((u) => `  ${u}`),
+        `Manual review (${result.manualReview.length}):`,
+        ...result.manualReview.map((m) => `  ${m.original}: ${m.reason}`),
+      ],
+      warnings: [...result.warnings],
+    },
+    asJson,
+  );
 }

--- a/packages/mcp-server/src/commands/migrate.ts
+++ b/packages/mcp-server/src/commands/migrate.ts
@@ -1,0 +1,11 @@
+/**
+ * `discord-mcp migrate` — placeholder for Plan 9 Phase D.
+ *
+ * Phase A wires up the sub-command surface. Phase D will diff
+ * legacy mcp.json shapes against the current schema and rewrite
+ * in place (with a .bak fallback).
+ */
+export async function migrateAction(): Promise<void> {
+  process.stdout.write('discord-mcp migrate: not yet implemented (Plan 9 Phase D)\n');
+  process.exitCode = 2;
+}

--- a/packages/mcp-server/src/commands/serve.test.ts
+++ b/packages/mcp-server/src/commands/serve.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock startStdio BEFORE importing serveAction so the import sees the mock.
+vi.mock('../transports/stdio.js', () => ({
+  startStdio: vi.fn(async () => {
+    // No-op: a real startStdio would block on the MCP transport.
+  }),
+}));
+
+const { serveAction } = await import('./serve.js');
+const { startStdio } = await import('../transports/stdio.js');
+
+const originalGateway = process.env.GATEWAY;
+
+beforeEach(() => {
+  delete process.env.GATEWAY;
+  vi.mocked(startStdio).mockClear();
+});
+
+afterEach(() => {
+  if (originalGateway !== undefined) {
+    process.env.GATEWAY = originalGateway;
+  } else {
+    delete process.env.GATEWAY;
+  }
+});
+
+describe('serveAction', () => {
+  it('calls startStdio with no gateway flag', async () => {
+    await serveAction({});
+    expect(startStdio).toHaveBeenCalledTimes(1);
+    expect(process.env.GATEWAY).toBeUndefined();
+  });
+
+  it('sets GATEWAY=1 when gateway: true', async () => {
+    await serveAction({ gateway: true });
+    expect(process.env.GATEWAY).toBe('1');
+    expect(startStdio).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not set GATEWAY when gateway: false', async () => {
+    await serveAction({ gateway: false });
+    expect(process.env.GATEWAY).toBeUndefined();
+    expect(startStdio).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls process.exit(1) on startStdio failure', async () => {
+    vi.mocked(startStdio).mockRejectedValueOnce(new Error('boom'));
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+      // Throw to abort serveAction so the test can assert without actually exiting.
+      throw new Error('process.exit called');
+    }) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      await expect(serveAction({})).rejects.toThrow('process.exit called');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(stderrSpy).toHaveBeenCalled();
+      const written = String(stderrSpy.mock.calls[0]?.[0] ?? '');
+      expect(written).toContain('discord-mcp failed to start: boom');
+    } finally {
+      exitSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+});

--- a/packages/mcp-server/src/commands/serve.ts
+++ b/packages/mcp-server/src/commands/serve.ts
@@ -1,0 +1,34 @@
+/**
+ * `discord-mcp serve` — start the stdio MCP server.
+ *
+ * Plan 9 Phase A. This is the sub-command form of the original
+ * top-level action in cli.ts; it remains the default sub-command
+ * (commander `{ isDefault: true }` in cli.ts) so `discord-mcp`
+ * with no args still boots stdio.
+ *
+ * `process.exit(1)` discipline: stdio cannot drain naturally on a
+ * boot failure (the transport never connected, so there is nothing
+ * to flush; the process is otherwise idle waiting on the event loop
+ * via signal handlers registered inside startStdio). serve is the
+ * ONE command that calls process.exit — every other command uses
+ * process.exitCode + return so Node drains stdout/stderr first.
+ */
+import { startStdio } from '../transports/stdio.js';
+
+export interface ServeOptions {
+  gateway?: boolean;
+}
+
+export async function serveAction(options: ServeOptions): Promise<void> {
+  if (options.gateway === true) {
+    process.env.GATEWAY = '1';
+  }
+  try {
+    await startStdio();
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stderr.write(`discord-mcp failed to start: ${msg}\n`);
+    // See file-level JSDoc for why this is the one allowed process.exit.
+    process.exit(1);
+  }
+}

--- a/packages/mcp-server/src/lib/checks/audit-sink.test.ts
+++ b/packages/mcp-server/src/lib/checks/audit-sink.test.ts
@@ -1,0 +1,126 @@
+import * as path from 'node:path';
+import type { Config } from '@discord-mcp/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.mock must be hoisted ABOVE the audit-sink.js import. ESM namespace
+// objects (e.g. `import * as fs from 'node:fs'`) are non-configurable, so
+// vi.spyOn(fs, 'accessSync') throws — we have to mock the module instead.
+// `accessSyncImpl` is a runtime-mutable function that each test rebinds
+// before calling auditSinkCheck.run().
+let accessSyncImpl: (...args: unknown[]) => void = () => undefined;
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    accessSync: ((...args: unknown[]) => accessSyncImpl(...args)) as typeof actual.accessSync,
+  };
+});
+
+const { auditSinkCheck } = await import('./audit-sink.js');
+
+function makeConfig(overrides: Partial<Config>): Config {
+  // We construct only the fields auditSinkCheck reads. The check signature
+  // takes Config, but it only touches MCP_AUDIT_SINK and MCP_AUDIT_FILE,
+  // so a structural cast is safe and avoids requiring zod here.
+  return overrides as unknown as Config;
+}
+
+beforeEach(() => {
+  // Reset to a permissive default (everything writable) before each test.
+  accessSyncImpl = () => undefined;
+});
+
+afterEach(() => {
+  accessSyncImpl = () => undefined;
+});
+
+describe('auditSinkCheck', () => {
+  it('has the correct id, description, and online flag', () => {
+    expect(auditSinkCheck.id).toBe('audit-sink');
+    expect(auditSinkCheck.description).toBe('Audit sink writability');
+    expect(auditSinkCheck.online).toBe(false);
+  });
+
+  it('returns warn when config is null (env-vars failed)', async () => {
+    const r = await auditSinkCheck.run(null);
+    expect(r.status).toBe('warn');
+    expect(r.message).toContain('env-vars');
+  });
+
+  it('returns ok for stderr sink without filesystem probe', async () => {
+    const cfg = makeConfig({ MCP_AUDIT_SINK: 'stderr' });
+    const r = await auditSinkCheck.run(cfg);
+    expect(r.status).toBe('ok');
+    expect(r.details?.sink).toBe('stderr');
+  });
+
+  it('returns ok for otlp sink', async () => {
+    const cfg = makeConfig({ MCP_AUDIT_SINK: 'otlp' });
+    const r = await auditSinkCheck.run(cfg);
+    expect(r.status).toBe('ok');
+    expect(r.details?.sink).toBe('otlp');
+  });
+
+  it('returns ok for none sink', async () => {
+    const cfg = makeConfig({ MCP_AUDIT_SINK: 'none' });
+    const r = await auditSinkCheck.run(cfg);
+    expect(r.status).toBe('ok');
+    expect(r.details?.sink).toBe('none');
+  });
+
+  it('returns ok for file sink when accessSync passes (file exists)', async () => {
+    const cfg = makeConfig({
+      MCP_AUDIT_SINK: 'file',
+      MCP_AUDIT_FILE: '/tmp/discord-mcp-audit.jsonl',
+    });
+    let calls = 0;
+    accessSyncImpl = () => {
+      calls += 1;
+    };
+    const r = await auditSinkCheck.run(cfg);
+    expect(r.status).toBe('ok');
+    expect(calls).toBeGreaterThan(0);
+  });
+
+  it('returns ok for file sink when file is missing but parent dir is writable', async () => {
+    const cfg = makeConfig({
+      MCP_AUDIT_SINK: 'file',
+      MCP_AUDIT_FILE: '/tmp/missing/audit.jsonl',
+    });
+    let call = 0;
+    accessSyncImpl = () => {
+      call += 1;
+      if (call === 1) {
+        throw new Error('ENOENT');
+      }
+      // Second call: parent-dir probe → succeed.
+    };
+    const r = await auditSinkCheck.run(cfg);
+    expect(r.status).toBe('ok');
+  });
+
+  it('returns fail for file sink when neither file nor parent dir is writable', async () => {
+    const cfg = makeConfig({
+      MCP_AUDIT_SINK: 'file',
+      MCP_AUDIT_FILE: '/nonexistent/no-perms/audit.jsonl',
+    });
+    accessSyncImpl = () => {
+      throw new Error('EACCES: permission denied');
+    };
+    const r = await auditSinkCheck.run(cfg);
+    expect(r.status).toBe('fail');
+    expect(r.message).toContain('not writable');
+    expect(r.details?.probedDir).toBe(
+      path.dirname(path.resolve('/nonexistent/no-perms/audit.jsonl')),
+    );
+  });
+
+  it('uses default audit file path when MCP_AUDIT_FILE is unset', async () => {
+    const cfg = makeConfig({ MCP_AUDIT_SINK: 'file' });
+    accessSyncImpl = () => undefined;
+    const r = await auditSinkCheck.run(cfg);
+    expect(r.status).toBe('ok');
+    expect(r.details?.file).toBe('./discord-mcp-audit.jsonl');
+  });
+});

--- a/packages/mcp-server/src/lib/checks/audit-sink.ts
+++ b/packages/mcp-server/src/lib/checks/audit-sink.ts
@@ -1,0 +1,97 @@
+/**
+ * `audit-sink` check — Plan 9 Phase B.
+ *
+ * Verifies the configured audit sink can actually be written to,
+ * WITHOUT performing an intrusive write:
+ *   - 'stderr' / 'otlp' / 'none' → always ok (no filesystem dependency)
+ *   - 'file' → use `fs.accessSync` to probe permission. If the file
+ *     exists, check W_OK | F_OK. If it doesn't exist (F_OK fails),
+ *     fall back to checking the parent directory's W_OK so users
+ *     get a clear actionable message before runtime.
+ *
+ * If `cfg === null` (env-vars failed to parse) we skip the file probe
+ * and report 'warn' — env-vars will already have failed, so we don't
+ * double-fail the run.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { DoctorCheck } from './index.js';
+
+const DEFAULT_AUDIT_FILE = './discord-mcp-audit.jsonl';
+
+function probeFileWritable(
+  filePath: string,
+): { ok: true } | { ok: false; reason: string; probedDir?: string } {
+  // First: does the file exist and is it writable?
+  try {
+    fs.accessSync(filePath, fs.constants.F_OK | fs.constants.W_OK);
+    return { ok: true };
+  } catch {
+    // Either F_OK failed (file doesn't exist) or W_OK failed
+    // (no permission). Both fall through to the dir-probe; if the
+    // directory is writable we treat the missing-file case as ok.
+  }
+
+  // Probe parent directory writability.
+  const dir = path.dirname(path.resolve(filePath));
+  try {
+    fs.accessSync(dir, fs.constants.W_OK);
+    return { ok: true };
+  } catch (e) {
+    return {
+      ok: false,
+      reason: e instanceof Error ? e.message : String(e),
+      probedDir: dir,
+    };
+  }
+}
+
+export const auditSinkCheck: DoctorCheck = {
+  id: 'audit-sink',
+  description: 'Audit sink writability',
+  online: false,
+  async run(config) {
+    if (config === null) {
+      return {
+        id: 'audit-sink',
+        status: 'warn',
+        message: 'Skipped — config did not parse (see env-vars)',
+      };
+    }
+
+    const sink = config.MCP_AUDIT_SINK;
+    const file = config.MCP_AUDIT_FILE;
+
+    if (sink !== 'file') {
+      return {
+        id: 'audit-sink',
+        status: 'ok',
+        message: `Audit sink "${sink}" requires no filesystem probe`,
+        details: { sink, file },
+      };
+    }
+
+    const filePath = file ?? DEFAULT_AUDIT_FILE;
+    const probe = probeFileWritable(filePath);
+
+    if (probe.ok) {
+      return {
+        id: 'audit-sink',
+        status: 'ok',
+        message: `Audit file "${filePath}" is writable`,
+        details: { sink, file: filePath },
+      };
+    }
+
+    return {
+      id: 'audit-sink',
+      status: 'fail',
+      message: `Audit file "${filePath}" is not writable: ${probe.reason}`,
+      details: {
+        sink,
+        file: filePath,
+        probedDir: probe.probedDir,
+      },
+    };
+  },
+};

--- a/packages/mcp-server/src/lib/checks/client-caps.test.ts
+++ b/packages/mcp-server/src/lib/checks/client-caps.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { clientCapsCheck } from './client-caps.js';
+
+describe('clientCapsCheck', () => {
+  it('has the correct id, description, and online flag', () => {
+    expect(clientCapsCheck.id).toBe('client-caps');
+    expect(clientCapsCheck.description).toBe('MCP capabilities advertised');
+    expect(clientCapsCheck.online).toBe(false);
+  });
+
+  it('always returns ok with the advertised method list', async () => {
+    const r = await clientCapsCheck.run(null);
+    expect(r.status).toBe('ok');
+    const advertised = r.details?.advertised;
+    expect(Array.isArray(advertised)).toBe(true);
+    expect(advertised).toContain('tools/list');
+    expect(advertised).toContain('tools/call');
+    expect(advertised).toContain('resources/list');
+    expect(advertised).toContain('resources/read');
+    expect(advertised).toContain('resources/subscribe');
+    expect(advertised).toContain('resources/unsubscribe');
+  });
+});

--- a/packages/mcp-server/src/lib/checks/client-caps.ts
+++ b/packages/mcp-server/src/lib/checks/client-caps.ts
@@ -1,0 +1,36 @@
+/**
+ * `client-caps` check — Plan 9 Phase B.
+ *
+ * Reports the MCP capabilities discord-mcp ADVERTISES at server boot.
+ * This is OFFLINE-only — actual client capability negotiation happens
+ * during the MCP `initialize` handshake, which doctor cannot observe
+ * without spawning the server. The list below mirrors what
+ * `mcp-server/src/server.ts` registers on the SDK Server instance.
+ *
+ * Always status='ok'. Functions as a self-describing "what does this
+ * server support?" for users wiring into a new MCP client.
+ */
+import type { DoctorCheck } from './index.js';
+
+const ADVERTISED = [
+  'tools/list',
+  'tools/call',
+  'resources/list',
+  'resources/read',
+  'resources/subscribe',
+  'resources/unsubscribe',
+] as const;
+
+export const clientCapsCheck: DoctorCheck = {
+  id: 'client-caps',
+  description: 'MCP capabilities advertised',
+  online: false,
+  async run() {
+    return {
+      id: 'client-caps',
+      status: 'ok',
+      message: `Advertises ${ADVERTISED.length} MCP methods (tools + resources)`,
+      details: { advertised: [...ADVERTISED] },
+    };
+  },
+};

--- a/packages/mcp-server/src/lib/checks/env-vars.test.ts
+++ b/packages/mcp-server/src/lib/checks/env-vars.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { envVarsCheck } from './env-vars.js';
+
+// Snapshot full env so we can restore the relevant keys after mutating.
+const originalToken = process.env.DISCORD_TOKEN;
+const originalAuditSink = process.env.MCP_AUDIT_SINK;
+
+const VALID_TOKEN = 'Bot ' + 'a'.repeat(60);
+
+beforeEach(() => {
+  delete process.env.DISCORD_TOKEN;
+  delete process.env.MCP_AUDIT_SINK;
+});
+
+afterEach(() => {
+  if (originalToken === undefined) {
+    delete process.env.DISCORD_TOKEN;
+  } else {
+    process.env.DISCORD_TOKEN = originalToken;
+  }
+  if (originalAuditSink === undefined) {
+    delete process.env.MCP_AUDIT_SINK;
+  } else {
+    process.env.MCP_AUDIT_SINK = originalAuditSink;
+  }
+});
+
+describe('envVarsCheck', () => {
+  it('has the correct id, description, and online flag', () => {
+    expect(envVarsCheck.id).toBe('env-vars');
+    expect(envVarsCheck.description).toBe('Config environment variables');
+    expect(envVarsCheck.online).toBe(false);
+  });
+
+  it('returns ok when DISCORD_TOKEN is present and Config parses', async () => {
+    process.env.DISCORD_TOKEN = VALID_TOKEN;
+    const r = await envVarsCheck.run(null);
+    expect(r.status).toBe('ok');
+  });
+
+  it('returns fail when DISCORD_TOKEN is missing', async () => {
+    const r = await envVarsCheck.run(null);
+    expect(r.status).toBe('fail');
+    expect(r.details?.errors).toBeDefined();
+    const errors = r.details?.errors as Array<{ path: string; message: string }> | undefined;
+    expect(Array.isArray(errors)).toBe(true);
+    expect(errors?.length).toBeGreaterThan(0);
+  });
+
+  it('returns fail when MCP_AUDIT_SINK has an invalid enum value', async () => {
+    process.env.DISCORD_TOKEN = VALID_TOKEN;
+    process.env.MCP_AUDIT_SINK = 'bogus-sink';
+    const r = await envVarsCheck.run(null);
+    expect(r.status).toBe('fail');
+  });
+});

--- a/packages/mcp-server/src/lib/checks/env-vars.ts
+++ b/packages/mcp-server/src/lib/checks/env-vars.ts
@@ -1,0 +1,83 @@
+/**
+ * `env-vars` check — Plan 9 Phase B.
+ *
+ * Validates the full Config schema by attempting `loadConfig(process.env)`.
+ * On success, status='ok'. On zod failure, we extract `issue.path` /
+ * `issue.message` pairs into details so users see exactly which env vars
+ * are wrong (without leaking values).
+ *
+ * We re-parse here even though doctor.ts has already attempted parse —
+ * the doctor entry point passes `cfg | null` to checks for re-use, but
+ * env-vars is the canonical reporter for parse failures, so we own the
+ * full re-parse to capture the zod issues array.
+ */
+import { loadConfig } from '@discord-mcp/core';
+import type { DoctorCheck } from './index.js';
+
+// We avoid importing the zod types directly — `zod` isn't a dependency
+// of mcp-server (Plan 9 "no new runtime deps" rule). Instead we duck-type
+// the {issues: [{path: [...], message: string}]} shape that ZodError
+// exposes. loadConfig() in @discord-mcp/core already wraps zod failures
+// in a fresh Error with a multi-line message; we look for either form.
+interface ZodIssueShape {
+  readonly path: ReadonlyArray<string | number>;
+  readonly message: string;
+}
+
+interface ZodErrorShape {
+  readonly issues: readonly ZodIssueShape[];
+}
+
+function isZodErrorLike(e: unknown): e is ZodErrorShape {
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    'issues' in e &&
+    Array.isArray((e as { issues?: unknown }).issues)
+  );
+}
+
+export const envVarsCheck: DoctorCheck = {
+  id: 'env-vars',
+  description: 'Config environment variables',
+  online: false,
+  async run() {
+    try {
+      loadConfig(process.env);
+      return {
+        id: 'env-vars',
+        status: 'ok',
+        message: 'All required environment variables are present and valid',
+      };
+    } catch (e) {
+      // loadConfig wraps zod errors in `new Error(...)` (see config.ts) —
+      // unwrap by re-parsing if we can find the zod error, else fall back
+      // to the message string. We try the underlying schema directly via
+      // a fresh import path? No — we just use the message which already
+      // lists path + message per issue.
+      if (isZodErrorLike(e)) {
+        const errors = e.issues.map((i) => ({
+          path: i.path.join('.'),
+          message: i.message,
+        }));
+        return {
+          id: 'env-vars',
+          status: 'fail',
+          message: `Config validation failed: ${errors.length} issue(s)`,
+          details: { errors },
+        };
+      }
+      // loadConfig throws Error with multi-line message like
+      // "Invalid configuration:\n  - DISCORD_TOKEN: too short"
+      // We surface it as a single-issue list so the JSON shape stays
+      // stable for downstream tooling.
+      const message = e instanceof Error ? e.message : String(e);
+      return {
+        id: 'env-vars',
+        status: 'fail',
+        message: 'Config validation failed',
+        details: { errors: [{ path: '', message }] },
+      };
+    }
+  },
+};

--- a/packages/mcp-server/src/lib/checks/index.ts
+++ b/packages/mcp-server/src/lib/checks/index.ts
@@ -1,0 +1,72 @@
+/**
+ * Doctor check registry — Plan 9 Phase B.
+ *
+ * Each check implements the {@link DoctorCheck} interface and is registered
+ * in {@link ALL_CHECKS}. The doctor command iterates the array, filters by
+ * the `--online` flag, and aggregates {@link CheckResult}s.
+ *
+ * Phase B ships 5 offline checks (`online: false`):
+ *   - node-version
+ *   - token-format
+ *   - env-vars
+ *   - audit-sink
+ *   - client-caps
+ *
+ * Phase C will append `tokenOnlineCheck` and `otelReachableCheck`
+ * (`online: true`). The array is intentionally simple `[a, b, c]` so
+ * future phases just push more entries.
+ */
+import type { Config } from '@discord-mcp/core';
+import { auditSinkCheck } from './audit-sink.js';
+import { clientCapsCheck } from './client-caps.js';
+import { envVarsCheck } from './env-vars.js';
+import { nodeVersionCheck } from './node-version.js';
+import { tokenFormatCheck } from './token-format.js';
+
+/**
+ * A single doctor check.
+ *
+ * `online` distinguishes offline checks (always run) from online ones
+ * that hit the network (only run when `--online` is passed).
+ *
+ * `run()` receives the parsed Config or `null` (if env-vars failed to
+ * parse) so each check can decide how to handle a missing config.
+ * Most checks read `process.env` directly when they need raw values
+ * (e.g. token-format inspects DISCORD_TOKEN even when Config rejected it).
+ */
+export interface DoctorCheck {
+  readonly id: string;
+  readonly description: string;
+  readonly online: boolean;
+  run(config: Config | null): Promise<CheckResult>;
+}
+
+/**
+ * Result emitted by a single check.
+ *
+ * `status`:
+ *   - 'ok'   → check passed, contributes 0 to exitCode
+ *   - 'warn' → non-fatal advisory, contributes 1 (clamped at fail)
+ *   - 'fail' → blocking, exitCode = 2
+ *
+ * `details` may include any redacted, structured payload (NEVER the
+ * actual token / secrets). Lengths and flags only.
+ */
+export interface CheckResult {
+  readonly id: string;
+  readonly status: 'ok' | 'warn' | 'fail';
+  readonly message: string;
+  readonly details?: Record<string, unknown>;
+}
+
+/**
+ * Registered checks in deterministic order. The doctor command preserves
+ * this order in its output. Phase C appends online checks to the tail.
+ */
+export const ALL_CHECKS: readonly DoctorCheck[] = [
+  nodeVersionCheck,
+  tokenFormatCheck,
+  envVarsCheck,
+  auditSinkCheck,
+  clientCapsCheck,
+];

--- a/packages/mcp-server/src/lib/checks/index.ts
+++ b/packages/mcp-server/src/lib/checks/index.ts
@@ -5,23 +5,28 @@
  * in {@link ALL_CHECKS}. The doctor command iterates the array, filters by
  * the `--online` flag, and aggregates {@link CheckResult}s.
  *
- * Phase B ships 5 offline checks (`online: false`):
+ * Phase B shipped 5 offline checks (`online: false`):
  *   - node-version
  *   - token-format
  *   - env-vars
  *   - audit-sink
  *   - client-caps
  *
- * Phase C will append `tokenOnlineCheck` and `otelReachableCheck`
- * (`online: true`). The array is intentionally simple `[a, b, c]` so
- * future phases just push more entries.
+ * Phase C appends 2 online checks (`online: true`, gated by --online):
+ *   - token-online
+ *   - otel-reachable
+ *
+ * The array is intentionally simple `[a, b, c]` so future phases just
+ * push more entries.
  */
 import type { Config } from '@discord-mcp/core';
 import { auditSinkCheck } from './audit-sink.js';
 import { clientCapsCheck } from './client-caps.js';
 import { envVarsCheck } from './env-vars.js';
 import { nodeVersionCheck } from './node-version.js';
+import { otelReachableCheck } from './otel-reachable.js';
 import { tokenFormatCheck } from './token-format.js';
+import { tokenOnlineCheck } from './token-online.js';
 
 /**
  * A single doctor check.
@@ -69,4 +74,6 @@ export const ALL_CHECKS: readonly DoctorCheck[] = [
   envVarsCheck,
   auditSinkCheck,
   clientCapsCheck,
+  tokenOnlineCheck,
+  otelReachableCheck,
 ];

--- a/packages/mcp-server/src/lib/checks/node-version.test.ts
+++ b/packages/mcp-server/src/lib/checks/node-version.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { nodeVersionCheck } from './node-version.js';
+
+const originalNode = process.versions.node;
+
+function setNodeVersion(v: string): void {
+  // process.versions is a frozen-ish object; redefine via Object.defineProperty
+  // so the spy survives strict-mode and we can restore it cleanly in afterEach.
+  Object.defineProperty(process.versions, 'node', {
+    value: v,
+    configurable: true,
+    writable: true,
+  });
+}
+
+beforeEach(() => {
+  setNodeVersion(originalNode);
+});
+
+afterEach(() => {
+  setNodeVersion(originalNode);
+});
+
+describe('nodeVersionCheck', () => {
+  it('has the correct id, description, and online flag', () => {
+    expect(nodeVersionCheck.id).toBe('node-version');
+    expect(nodeVersionCheck.description).toBe('Node.js >= 20.11');
+    expect(nodeVersionCheck.online).toBe(false);
+  });
+
+  it('returns ok when running >=20.11.0 (exact match)', async () => {
+    setNodeVersion('20.11.0');
+    const r = await nodeVersionCheck.run(null);
+    expect(r.status).toBe('ok');
+    expect(r.details).toEqual({ running: '20.11.0', required: '>=20.11.0' });
+  });
+
+  it('returns ok for higher minor (20.12.0)', async () => {
+    setNodeVersion('20.12.5');
+    const r = await nodeVersionCheck.run(null);
+    expect(r.status).toBe('ok');
+  });
+
+  it('returns ok for higher major (22.0.0)', async () => {
+    setNodeVersion('22.0.0');
+    const r = await nodeVersionCheck.run(null);
+    expect(r.status).toBe('ok');
+  });
+
+  it('returns fail for lower minor (20.10.0)', async () => {
+    setNodeVersion('20.10.0');
+    const r = await nodeVersionCheck.run(null);
+    expect(r.status).toBe('fail');
+    expect(r.message).toContain('20.10.0');
+    expect(r.message).toContain('>=20.11.0');
+  });
+
+  it('returns fail for lower major (18.20.0)', async () => {
+    setNodeVersion('18.20.0');
+    const r = await nodeVersionCheck.run(null);
+    expect(r.status).toBe('fail');
+  });
+
+  it('returns fail for an unparseable version string', async () => {
+    setNodeVersion('not-a-version');
+    const r = await nodeVersionCheck.run(null);
+    expect(r.status).toBe('fail');
+    expect(r.message).toContain('Could not parse');
+  });
+});

--- a/packages/mcp-server/src/lib/checks/node-version.ts
+++ b/packages/mcp-server/src/lib/checks/node-version.ts
@@ -1,0 +1,84 @@
+/**
+ * `node-version` check — Plan 9 Phase B.
+ *
+ * Verifies the running Node.js >= 20.11.0. The package.json `engines.node`
+ * field declares `">=20.11"` (Node 20 LTS minimum that ships ESM JSON
+ * import assertions and stable fetch). We enforce this at runtime via
+ * doctor so users get a clear actionable error instead of a cryptic
+ * import or syntax failure later.
+ *
+ * Implementation reads `process.versions.node` (e.g. "20.11.1") and
+ * does a manual semver compare on the major/minor/patch tuple — we
+ * don't pull in the `semver` package because that would violate the
+ * "no new runtime deps" rule for Phase B.
+ */
+import type { DoctorCheck } from './index.js';
+
+const REQUIRED_MAJOR = 20;
+const REQUIRED_MINOR = 11;
+const REQUIRED_PATCH = 0;
+
+function parseNodeVersion(v: string): [number, number, number] | null {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(v);
+  if (m === null) {
+    return null;
+  }
+  // Coerce via Number() — the regex group already constrains to digits,
+  // so NaN is impossible. Coalesce-or-throw belt-and-braces is overkill.
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function meetsRequirement(parsed: [number, number, number]): boolean {
+  const [major, minor, patch] = parsed;
+  if (major > REQUIRED_MAJOR) {
+    return true;
+  }
+  if (major < REQUIRED_MAJOR) {
+    return false;
+  }
+  // Same major.
+  if (minor > REQUIRED_MINOR) {
+    return true;
+  }
+  if (minor < REQUIRED_MINOR) {
+    return false;
+  }
+  // Same major.minor.
+  return patch >= REQUIRED_PATCH;
+}
+
+export const nodeVersionCheck: DoctorCheck = {
+  id: 'node-version',
+  description: 'Node.js >= 20.11',
+  online: false,
+  async run() {
+    const running = process.versions.node;
+    const parsed = parseNodeVersion(running);
+    const required = `>=${REQUIRED_MAJOR}.${REQUIRED_MINOR}.${REQUIRED_PATCH}`;
+
+    if (parsed === null) {
+      return {
+        id: 'node-version',
+        status: 'fail',
+        message: `Could not parse Node.js version "${running}"`,
+        details: { running, required },
+      };
+    }
+
+    if (meetsRequirement(parsed)) {
+      return {
+        id: 'node-version',
+        status: 'ok',
+        message: `Node.js ${running} satisfies ${required}`,
+        details: { running, required },
+      };
+    }
+
+    return {
+      id: 'node-version',
+      status: 'fail',
+      message: `Node.js ${running} is older than ${required}`,
+      details: { running, required },
+    };
+  },
+};

--- a/packages/mcp-server/src/lib/checks/otel-reachable.test.ts
+++ b/packages/mcp-server/src/lib/checks/otel-reachable.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit tests for `otelReachableCheck` — Plan 9 Phase C.
+ *
+ * Like token-online.test.ts we mock `fetch` via `vi.stubGlobal`. The
+ * privacy invariant — OTEL_EXPORTER_OTLP_HEADERS never appears in
+ * `details` or `message` — is exercised by a dedicated test that uses
+ * a recognizable token-shaped header value.
+ */
+import type { Config } from '@discord-mcp/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { otelReachableCheck } from './otel-reachable.js';
+
+function makeConfig(overrides: Partial<Config>): Config {
+  // Defaults that keep the OTel branch deterministic. Tests override
+  // OTEL_ENABLED / endpoint / headers as needed.
+  return {
+    OTEL_ENABLED: false,
+    OTEL_EXPORTER_OTLP_ENDPOINT: undefined,
+    OTEL_EXPORTER_OTLP_HEADERS: undefined,
+    ...overrides,
+  } as unknown as Config;
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('otelReachableCheck', () => {
+  it('has the correct id, description, and online flag', () => {
+    expect(otelReachableCheck.id).toBe('otel-reachable');
+    expect(otelReachableCheck.description).toBe('OTLP endpoint reachability');
+    expect(otelReachableCheck.online).toBe(true);
+  });
+
+  it('returns warn without making a request when config is null', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await otelReachableCheck.run(null);
+    expect(r.status).toBe('warn');
+    expect(r.message).toContain('config invalid');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns ok WITHOUT making a network call when OTEL_ENABLED=false', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await otelReachableCheck.run(makeConfig({ OTEL_ENABLED: false }));
+    expect(r.status).toBe('ok');
+    expect(r.message).toContain('OTEL_ENABLED=false');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns warn when OTEL_ENABLED=true but no endpoint is set', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await otelReachableCheck.run(
+      makeConfig({ OTEL_ENABLED: true, OTEL_EXPORTER_OTLP_ENDPOINT: undefined }),
+    );
+    expect(r.status).toBe('warn');
+    expect(r.message).toContain('no OTLP endpoint');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns ok on 200', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await otelReachableCheck.run(
+      makeConfig({
+        OTEL_ENABLED: true,
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+      }),
+    );
+    expect(r.status).toBe('ok');
+    expect(r.details?.status).toBe(200);
+    expect(r.details?.method).toBe('HEAD');
+  });
+
+  it('returns ok on 204', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await otelReachableCheck.run(
+      makeConfig({
+        OTEL_ENABLED: true,
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+      }),
+    );
+    expect(r.status).toBe('ok');
+    expect(r.details?.status).toBe(204);
+  });
+
+  it('returns ok on 405 (method not allowed but server alive)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 405 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await otelReachableCheck.run(
+      makeConfig({
+        OTEL_ENABLED: true,
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+      }),
+    );
+    expect(r.status).toBe('ok');
+    expect(r.details?.status).toBe(405);
+  });
+
+  it('returns warn on non-405 4xx (e.g. 401)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await otelReachableCheck.run(
+      makeConfig({
+        OTEL_ENABLED: true,
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+      }),
+    );
+    expect(r.status).toBe('warn');
+    expect(r.message).toContain('rejected');
+    expect(r.details?.status).toBe(401);
+  });
+
+  it('returns warn on 5xx', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 503 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await otelReachableCheck.run(
+      makeConfig({
+        OTEL_ENABLED: true,
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+      }),
+    );
+    expect(r.status).toBe('warn');
+    expect(r.message).toContain('503');
+    expect(r.details?.status).toBe(503);
+  });
+
+  it('returns fail on connection refused', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNREFUSED 127.0.0.1:4318'));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await otelReachableCheck.run(
+      makeConfig({
+        OTEL_ENABLED: true,
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+      }),
+    );
+    expect(r.status).toBe('fail');
+    expect(r.message).toContain('unreachable');
+    expect(r.message).toContain('ECONNREFUSED');
+  });
+
+  it('returns fail on timeout (AbortError) via fake timers', async () => {
+    const fetchMock = vi.fn((_url: string, init: { signal: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        init.signal.addEventListener('abort', () => {
+          reject(new Error('The operation was aborted'));
+        });
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    vi.useFakeTimers();
+    const promise = otelReachableCheck.run(
+      makeConfig({
+        OTEL_ENABLED: true,
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(3001);
+    const r = await promise;
+    vi.useRealTimers();
+
+    expect(r.status).toBe('fail');
+    expect(r.message).toContain('unreachable');
+  });
+
+  it('NEVER includes OTEL_EXPORTER_OTLP_HEADERS value in details/message', async () => {
+    const SECRET_HEADER = 'authorization=Bearer super-secret-token-xyz';
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await otelReachableCheck.run(
+      makeConfig({
+        OTEL_ENABLED: true,
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+        OTEL_EXPORTER_OTLP_HEADERS: SECRET_HEADER,
+      }),
+    );
+    const dump = JSON.stringify(r);
+    expect(dump).not.toContain('Bearer');
+    expect(dump).not.toContain('super-secret-token-xyz');
+    // We DO surface the count.
+    expect(r.details?.headers_configured).toBe(1);
+  });
+
+  it('counts comma-separated headers correctly', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await otelReachableCheck.run(
+      makeConfig({
+        OTEL_ENABLED: true,
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+        OTEL_EXPORTER_OTLP_HEADERS: 'a=1,b=2,c=3',
+      }),
+    );
+    expect(r.details?.headers_configured).toBe(3);
+  });
+
+  it('hits the configured endpoint at /v1/traces with HEAD method', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await otelReachableCheck.run(
+      makeConfig({
+        OTEL_ENABLED: true,
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+      }),
+    );
+    const [url, init] = fetchMock.mock.calls[0] as [
+      string,
+      { method: string; signal: AbortSignal },
+    ];
+    expect(url).toBe('http://localhost:4318/v1/traces');
+    expect(init.method).toBe('HEAD');
+  });
+
+  it('strips trailing slash from endpoint to avoid double "/"', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await otelReachableCheck.run(
+      makeConfig({
+        OTEL_ENABLED: true,
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318/',
+      }),
+    );
+    const [url] = fetchMock.mock.calls[0] as [string, unknown];
+    expect(url).toBe('http://localhost:4318/v1/traces');
+  });
+});

--- a/packages/mcp-server/src/lib/checks/otel-reachable.ts
+++ b/packages/mcp-server/src/lib/checks/otel-reachable.ts
@@ -1,0 +1,165 @@
+/**
+ * `otel-reachable` check — Plan 9 Phase C.
+ *
+ * Probes the configured OTLP endpoint with an HTTP HEAD request to
+ * `${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces`. We treat 200/204/405 as
+ * "server alive" (405 happens when the endpoint requires POST but the
+ * port/host responds), 4xx as a warning (auth/header config issue) and
+ * 5xx / network errors as failures depending on which.
+ *
+ * Privacy: `OTEL_EXPORTER_OTLP_HEADERS` value is NEVER included in the
+ * result (it can contain bearer tokens, API keys, etc.). We surface
+ * only a count when relevant.
+ *
+ * Skip semantics:
+ *   - cfg === null → 'warn' (canonical reporter is env-vars)
+ *   - !OTEL_ENABLED → 'ok', skip request entirely
+ *   - OTEL_ENABLED but no endpoint → 'warn'
+ *
+ * Timeout: 3 seconds via AbortController. Shorter than token-online's
+ * 5s because OTLP collectors are typically local / on-network.
+ */
+import type { DoctorCheck } from './index.js';
+
+const REQUEST_TIMEOUT_MS = 3000;
+
+/**
+ * Count the number of comma-separated key=value pairs in
+ * OTEL_EXPORTER_OTLP_HEADERS without exposing any value. Used only for
+ * surfacing `headers_configured: <n>` in details — never the raw string.
+ */
+function countHeaders(raw: string | undefined): number {
+  if (raw === undefined || raw === '') {
+    return 0;
+  }
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0).length;
+}
+
+export const otelReachableCheck: DoctorCheck = {
+  id: 'otel-reachable',
+  description: 'OTLP endpoint reachability',
+  online: true,
+  async run(config) {
+    if (config === null) {
+      return {
+        id: 'otel-reachable',
+        status: 'warn',
+        message: 'cannot verify — config invalid',
+      };
+    }
+
+    if (!config.OTEL_ENABLED) {
+      return {
+        id: 'otel-reachable',
+        status: 'ok',
+        message: 'OTel disabled (OTEL_ENABLED=false)',
+      };
+    }
+
+    const endpoint = config.OTEL_EXPORTER_OTLP_ENDPOINT;
+    if (endpoint === undefined) {
+      return {
+        id: 'otel-reachable',
+        status: 'warn',
+        message: 'OTEL_ENABLED=true but no OTLP endpoint set',
+      };
+    }
+
+    // Trim trailing slash so `${endpoint}/v1/traces` doesn't double-up.
+    const base = endpoint.endsWith('/') ? endpoint.slice(0, -1) : endpoint;
+    const url = `${base}/v1/traces`;
+    const headersConfigured = countHeaders(config.OTEL_EXPORTER_OTLP_HEADERS);
+
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const res = await fetch(url, {
+        method: 'HEAD',
+        signal: ctrl.signal,
+      });
+
+      // 200/204 → server explicitly accepted HEAD.
+      // 405 → "method not allowed" — server is alive but only accepts POST,
+      // which is what the OTLP HTTP exporter actually uses. Treat as ok.
+      if (res.status === 200 || res.status === 204 || res.status === 405) {
+        return {
+          id: 'otel-reachable',
+          status: 'ok',
+          message: `OTLP endpoint reachable (HEAD → ${res.status})`,
+          details: {
+            endpoint,
+            method: 'HEAD',
+            status: res.status,
+            headers_configured: headersConfigured,
+          },
+        };
+      }
+
+      // Other 4xx — endpoint exists but rejected our request. Likely an
+      // auth/header issue; surface as warn so users can investigate but
+      // don't block.
+      if (res.status >= 400 && res.status < 500) {
+        return {
+          id: 'otel-reachable',
+          status: 'warn',
+          message: 'endpoint reachable but rejected — check headers/auth/path',
+          details: {
+            endpoint,
+            method: 'HEAD',
+            status: res.status,
+            headers_configured: headersConfigured,
+          },
+        };
+      }
+
+      // 5xx — server is up but unhealthy. Warn (recoverable).
+      if (res.status >= 500 && res.status < 600) {
+        return {
+          id: 'otel-reachable',
+          status: 'warn',
+          message: `endpoint server error: ${res.status}`,
+          details: {
+            endpoint,
+            method: 'HEAD',
+            status: res.status,
+            headers_configured: headersConfigured,
+          },
+        };
+      }
+
+      // 1xx/3xx — unusual. Surface as warn with status.
+      return {
+        id: 'otel-reachable',
+        status: 'warn',
+        message: `unexpected response: ${res.status}`,
+        details: {
+          endpoint,
+          method: 'HEAD',
+          status: res.status,
+          headers_configured: headersConfigured,
+        },
+      };
+    } catch (e) {
+      // ECONNREFUSED, ENOTFOUND, AbortError (timeout) — collector unreachable.
+      // This is a fail (not warn) because if you've enabled OTEL_ENABLED and
+      // set an endpoint, you almost certainly want spans to actually export.
+      const message = e instanceof Error ? e.message : String(e);
+      return {
+        id: 'otel-reachable',
+        status: 'fail',
+        message: `OTel endpoint unreachable: ${message}`,
+        details: {
+          endpoint,
+          method: 'HEAD',
+          headers_configured: headersConfigured,
+        },
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  },
+};

--- a/packages/mcp-server/src/lib/checks/token-format.test.ts
+++ b/packages/mcp-server/src/lib/checks/token-format.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { tokenFormatCheck } from './token-format.js';
+
+const originalToken = process.env.DISCORD_TOKEN;
+
+beforeEach(() => {
+  delete process.env.DISCORD_TOKEN;
+});
+
+afterEach(() => {
+  if (originalToken === undefined) {
+    delete process.env.DISCORD_TOKEN;
+  } else {
+    process.env.DISCORD_TOKEN = originalToken;
+  }
+});
+
+// 60-char token body — comfortably above the 50-char floor and shaped
+// like a real Discord bot token (alnum + dot + dash + underscore).
+const VALID_BODY = 'a'.repeat(24) + '.' + 'b'.repeat(6) + '.' + 'c'.repeat(28);
+
+describe('tokenFormatCheck', () => {
+  it('has the correct id, description, and online flag', () => {
+    expect(tokenFormatCheck.id).toBe('token-format');
+    expect(tokenFormatCheck.description).toBe('DISCORD_TOKEN format check');
+    expect(tokenFormatCheck.online).toBe(false);
+  });
+
+  it('returns fail when DISCORD_TOKEN is unset', async () => {
+    const r = await tokenFormatCheck.run(null);
+    expect(r.status).toBe('fail');
+    expect(r.message).toContain('not set');
+    expect(r.details).toEqual({ length: 0, hasBotPrefix: false });
+  });
+
+  it('returns fail when DISCORD_TOKEN is empty string', async () => {
+    process.env.DISCORD_TOKEN = '';
+    const r = await tokenFormatCheck.run(null);
+    expect(r.status).toBe('fail');
+    expect(r.message).toContain('not set');
+  });
+
+  it('returns fail when token does not match expected shape (too short)', async () => {
+    process.env.DISCORD_TOKEN = 'too-short';
+    const r = await tokenFormatCheck.run(null);
+    expect(r.status).toBe('fail');
+    expect(r.message).toContain('does not match');
+    expect(r.details?.length).toBe(9);
+    expect(r.details?.hasBotPrefix).toBe(false);
+  });
+
+  it('returns fail when token contains illegal characters', async () => {
+    process.env.DISCORD_TOKEN = 'Bot ' + '!'.repeat(60);
+    const r = await tokenFormatCheck.run(null);
+    expect(r.status).toBe('fail');
+  });
+
+  it('returns warn when token is valid but missing "Bot " prefix', async () => {
+    process.env.DISCORD_TOKEN = VALID_BODY;
+    const r = await tokenFormatCheck.run(null);
+    expect(r.status).toBe('warn');
+    expect(r.message).toContain('Bot ');
+    expect(r.details?.hasBotPrefix).toBe(false);
+    expect(r.details?.length).toBe(VALID_BODY.length);
+  });
+
+  it('returns ok when token has "Bot " prefix and valid shape', async () => {
+    process.env.DISCORD_TOKEN = 'Bot ' + VALID_BODY;
+    const r = await tokenFormatCheck.run(null);
+    expect(r.status).toBe('ok');
+    expect(r.details?.hasBotPrefix).toBe(true);
+    expect(r.details?.length).toBe(('Bot ' + VALID_BODY).length);
+  });
+
+  it('NEVER includes the actual token value in details', async () => {
+    process.env.DISCORD_TOKEN = 'Bot ' + VALID_BODY;
+    const r = await tokenFormatCheck.run(null);
+    const dump = JSON.stringify(r);
+    expect(dump).not.toContain(VALID_BODY);
+  });
+});

--- a/packages/mcp-server/src/lib/checks/token-format.ts
+++ b/packages/mcp-server/src/lib/checks/token-format.ts
@@ -1,0 +1,66 @@
+/**
+ * `token-format` check — Plan 9 Phase B.
+ *
+ * Validates the *shape* of `DISCORD_TOKEN` without making any network
+ * calls. We read `process.env.DISCORD_TOKEN` directly (NOT the parsed
+ * Config) because Config.parse rejects empty/short tokens, and we want
+ * to report a clean "missing/malformed" message even when Config fails.
+ *
+ * Token redaction: details NEVER include the actual token. Only its
+ * length and whether it begins with the literal `Bot ` prefix.
+ */
+import type { DoctorCheck } from './index.js';
+
+// Discord bot tokens are typically 70+ chars (3 base64url segments
+// separated by dots). 50 is a conservative lower bound that matches
+// the Config schema's min(50). We accept an optional `Bot ` prefix
+// because Discord.js auto-adds it when missing — but we still warn
+// if it's missing because some libraries (e.g. raw fetch) require it.
+const TOKEN_REGEX = /^(Bot )?[A-Za-z0-9._-]{50,}$/;
+
+export const tokenFormatCheck: DoctorCheck = {
+  id: 'token-format',
+  description: 'DISCORD_TOKEN format check',
+  online: false,
+  async run() {
+    const token = process.env.DISCORD_TOKEN;
+
+    if (token === undefined || token === '') {
+      return {
+        id: 'token-format',
+        status: 'fail',
+        message: 'DISCORD_TOKEN is not set',
+        details: { length: 0, hasBotPrefix: false },
+      };
+    }
+
+    const hasBotPrefix = token.startsWith('Bot ');
+    const length = token.length;
+
+    if (!TOKEN_REGEX.test(token)) {
+      return {
+        id: 'token-format',
+        status: 'fail',
+        message: 'DISCORD_TOKEN does not match expected bot-token shape',
+        details: { length, hasBotPrefix },
+      };
+    }
+
+    if (!hasBotPrefix) {
+      return {
+        id: 'token-format',
+        status: 'warn',
+        message:
+          'DISCORD_TOKEN is missing the "Bot " prefix (Discord.js auto-adds it, but raw REST callers may need it)',
+        details: { length, hasBotPrefix },
+      };
+    }
+
+    return {
+      id: 'token-format',
+      status: 'ok',
+      message: 'DISCORD_TOKEN format looks valid',
+      details: { length, hasBotPrefix },
+    };
+  },
+};

--- a/packages/mcp-server/src/lib/checks/token-online.test.ts
+++ b/packages/mcp-server/src/lib/checks/token-online.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for `tokenOnlineCheck` — Plan 9 Phase C.
+ *
+ * We mock global `fetch` via `vi.stubGlobal` per Phase C plan; vitest
+ * auto-restores stubbed globals between tests but we still call
+ * `vi.unstubAllGlobals()` in afterEach for explicitness (and to be safe
+ * against any test running in isolation).
+ */
+import type { Config } from '@discord-mcp/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { tokenOnlineCheck } from './token-online.js';
+
+function makeConfig(token: string): Config {
+  // tokenOnlineCheck only reads DISCORD_TOKEN — structural cast keeps the
+  // test focused without constructing every Config field.
+  return { DISCORD_TOKEN: token } as unknown as Config;
+}
+
+const VALID_TOKEN = `Bot ${'a'.repeat(60)}`;
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('tokenOnlineCheck', () => {
+  it('has the correct id, description, and online flag', () => {
+    expect(tokenOnlineCheck.id).toBe('token-online');
+    expect(tokenOnlineCheck.description).toBe('Discord token verification (live)');
+    expect(tokenOnlineCheck.online).toBe(true);
+  });
+
+  it('returns warn without making a request when config is null', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await tokenOnlineCheck.run(null);
+    expect(r.status).toBe('warn');
+    expect(r.message).toContain('config invalid');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns ok with bot identity on 200 response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: '1234', username: 'bot-name', bot: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const r = await tokenOnlineCheck.run(makeConfig(VALID_TOKEN));
+    expect(r.status).toBe('ok');
+    expect(r.message).toContain('bot-name');
+    expect(r.details).toEqual({ username: 'bot-name', id: '1234', bot: true });
+  });
+
+  it('uses Authorization: Bot <token> with leading "Bot " stripped+re-added', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: '1', username: 'x', bot: false }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Pass a token already prefixed with "Bot " — we should still send
+    // exactly one "Bot " prefix in the Authorization header.
+    await tokenOnlineCheck.run(makeConfig(`Bot ${'x'.repeat(60)}`));
+    const headers = (fetchMock.mock.calls[0]?.[1] as { headers: Record<string, string> }).headers;
+    const auth = headers.Authorization ?? '';
+    expect(auth).toBe(`Bot ${'x'.repeat(60)}`);
+    expect(auth.startsWith('Bot Bot ')).toBe(false);
+  });
+
+  it('returns fail on 401', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await tokenOnlineCheck.run(makeConfig(VALID_TOKEN));
+    expect(r.status).toBe('fail');
+    expect(r.message).toContain('401');
+    expect(r.details).toEqual({ status: 401 });
+  });
+
+  it('returns fail on 403', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 403 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await tokenOnlineCheck.run(makeConfig(VALID_TOKEN));
+    expect(r.status).toBe('fail');
+    expect(r.message).toContain('403');
+  });
+
+  it('returns warn on 429 with retry_after_seconds parsed from header', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('', {
+        status: 429,
+        headers: { 'retry-after': '7' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await tokenOnlineCheck.run(makeConfig(VALID_TOKEN));
+    expect(r.status).toBe('warn');
+    expect(r.message).toContain('rate-limited');
+    expect(r.details?.retry_after_seconds).toBe(7);
+  });
+
+  it('returns warn on 429 with retry_after_seconds=0 when header missing', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 429 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await tokenOnlineCheck.run(makeConfig(VALID_TOKEN));
+    expect(r.status).toBe('warn');
+    expect(r.details?.retry_after_seconds).toBe(0);
+  });
+
+  it('returns warn for other 4xx/5xx (e.g. 500)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 500 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await tokenOnlineCheck.run(makeConfig(VALID_TOKEN));
+    expect(r.status).toBe('warn');
+    expect(r.details?.status).toBe(500);
+  });
+
+  it('returns warn on network error', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await tokenOnlineCheck.run(makeConfig(VALID_TOKEN));
+    expect(r.status).toBe('warn');
+    expect(r.message).toContain('ECONNREFUSED');
+    expect(r.message).toContain('offline or unreachable');
+  });
+
+  it('returns warn on timeout (AbortError)', async () => {
+    // Simulate a fetch that respects AbortSignal and rejects with AbortError
+    // when aborted. We don't actually wait the 5s timeout — we trigger abort
+    // by returning a never-resolving promise that rejects when signal aborts.
+    const fetchMock = vi.fn((_url: string, init: { signal: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        init.signal.addEventListener('abort', () => {
+          reject(new Error('The operation was aborted'));
+        });
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Use fake timers so setTimeout(5000) fires immediately.
+    vi.useFakeTimers();
+    const promise = tokenOnlineCheck.run(makeConfig(VALID_TOKEN));
+    await vi.advanceTimersByTimeAsync(5001);
+    const r = await promise;
+    vi.useRealTimers();
+
+    expect(r.status).toBe('warn');
+    expect(r.message).toContain('offline or unreachable');
+  });
+
+  it('NEVER includes the actual token in details or message', async () => {
+    const secretToken = `Bot ${'s'.repeat(60)}`;
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await tokenOnlineCheck.run(makeConfig(secretToken));
+    const dump = JSON.stringify(r);
+    expect(dump).not.toContain(secretToken);
+    expect(dump).not.toContain('s'.repeat(60));
+  });
+
+  it('handles 200 with non-JSON body gracefully', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('not json', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await tokenOnlineCheck.run(makeConfig(VALID_TOKEN));
+    expect(r.status).toBe('ok');
+    expect(r.details?.username).toBe(null);
+  });
+});

--- a/packages/mcp-server/src/lib/checks/token-online.ts
+++ b/packages/mcp-server/src/lib/checks/token-online.ts
@@ -1,0 +1,141 @@
+/**
+ * `token-online` check — Plan 9 Phase C.
+ *
+ * Verifies the configured DISCORD_TOKEN against the live Discord REST API
+ * by hitting `GET /users/@me`. This is the only check that proves the
+ * token is *currently valid* and the bot account is reachable; the offline
+ * `token-format` check only verifies shape.
+ *
+ * Privacy: the token NEVER appears in `details` or `message`. We only
+ * surface the resolved bot identity (username, id, bot flag) on success
+ * and HTTP status / error message on failure.
+ *
+ * Test-only escape hatch: `DISCORD_API_BASE_URL` env override. Defaults
+ * to `https://discord.com/api/v10`. Integration tests set this to a
+ * loopback `node:http` server (see doctor.integration.test.ts). NEVER
+ * documented in user-facing help — it exists purely to avoid pulling in
+ * `nock` / `msw` for ONLINE network tests.
+ *
+ * Timeout: 5 seconds via AbortController. On abort we report 'warn'
+ * (treating the result as inconclusive rather than failed) so transient
+ * network issues don't block the user from running their MCP server.
+ */
+import type { DoctorCheck } from './index.js';
+
+const DISCORD_API_BASE = process.env.DISCORD_API_BASE_URL ?? 'https://discord.com/api/v10';
+const REQUEST_TIMEOUT_MS = 5000;
+
+/**
+ * Discord requires an exact `Authorization: Bot <token>` header. The
+ * config schema accepts either bare tokens or `Bot `-prefixed ones; we
+ * normalize by stripping any leading `Bot ` and re-adding it ourselves.
+ */
+function authHeader(token: string): string {
+  const stripped = token.startsWith('Bot ') ? token.slice(4) : token;
+  return `Bot ${stripped}`;
+}
+
+interface DiscordUserResponse {
+  readonly id?: string;
+  readonly username?: string;
+  readonly bot?: boolean;
+}
+
+export const tokenOnlineCheck: DoctorCheck = {
+  id: 'token-online',
+  description: 'Discord token verification (live)',
+  online: true,
+  async run(config) {
+    if (config === null) {
+      return {
+        id: 'token-online',
+        status: 'warn',
+        message: 'cannot verify — config invalid',
+      };
+    }
+
+    const url = `${DISCORD_API_BASE}/users/@me`;
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const res = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: authHeader(config.DISCORD_TOKEN),
+          'User-Agent': 'discord-mcp-doctor (https://github.com/cappylab/discord-mcp)',
+        },
+        signal: ctrl.signal,
+      });
+
+      if (res.status === 200) {
+        // Parse defensively — a 200 with malformed body still implies the
+        // token is accepted, so we degrade gracefully if JSON parse fails.
+        let data: DiscordUserResponse = {};
+        try {
+          data = (await res.json()) as DiscordUserResponse;
+        } catch {
+          // Empty / non-JSON 200 is acceptable; surface what we can.
+        }
+        return {
+          id: 'token-online',
+          status: 'ok',
+          message: data.username
+            ? `Discord accepted token for ${data.username}`
+            : 'Discord accepted token',
+          details: {
+            username: data.username ?? null,
+            id: data.id ?? null,
+            bot: data.bot ?? false,
+          },
+        };
+      }
+
+      if (res.status === 401) {
+        return {
+          id: 'token-online',
+          status: 'fail',
+          message: 'token invalid (401)',
+          details: { status: 401 },
+        };
+      }
+
+      if (res.status === 403) {
+        return {
+          id: 'token-online',
+          status: 'fail',
+          message: 'token disabled or bot kicked (403)',
+          details: { status: 403 },
+        };
+      }
+
+      if (res.status === 429) {
+        const retryAfter = parseInt(res.headers.get('retry-after') ?? '0', 10);
+        return {
+          id: 'token-online',
+          status: 'warn',
+          message: 'rate-limited; cannot verify right now',
+          details: { status: 429, retry_after_seconds: retryAfter },
+        };
+      }
+
+      return {
+        id: 'token-online',
+        status: 'warn',
+        message: `unexpected response from Discord: ${res.status}`,
+        details: { status: res.status },
+      };
+    } catch (e) {
+      // AbortError (timeout) and network errors (DNS, ECONNREFUSED, etc.)
+      // both surface as 'warn' — the doctor user can still proceed offline.
+      const message = e instanceof Error ? e.message : String(e);
+      return {
+        id: 'token-online',
+        status: 'warn',
+        message: `offline or unreachable: ${message}`,
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  },
+};

--- a/packages/mcp-server/src/lib/client-snippets/_shared.ts
+++ b/packages/mcp-server/src/lib/client-snippets/_shared.ts
@@ -1,0 +1,54 @@
+/**
+ * Internal shared rendering for MCP client snippets.
+ *
+ * All four supported clients (Claude Desktop, Claude Code, Cursor,
+ * Generic) converged on the same `mcpServers.<id>.{command,args,env}`
+ * JSON schema, so the per-client modules differ only in id /
+ * displayName / configFilePath / instructions. The actual JSON shape
+ * is generated here once.
+ */
+import type { SnippetConfig } from './types.js';
+
+/**
+ * Build the `{ command, args, env }` payload for a single MCP server
+ * entry. Args are merged: caller-provided `serverArgs` first, then
+ * `--gateway` appended when `cfg.gateway === true`. Env merges
+ * `DISCORD_TOKEN` (always present) with any extra `cfg.envVars`.
+ */
+function renderServerEntry(cfg: SnippetConfig): {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+} {
+  const args = [...(cfg.serverArgs ?? [])];
+  if (cfg.gateway === true) {
+    args.push('--gateway');
+  }
+
+  const env: Record<string, string> = {
+    DISCORD_TOKEN: cfg.discordToken,
+    ...(cfg.envVars ?? {}),
+  };
+
+  return {
+    command: cfg.serverPath,
+    args,
+    env,
+  };
+}
+
+/**
+ * Render the full top-level JSON document with a single `discord-mcp`
+ * server registered under `mcpServers`.
+ *
+ * The output is pretty-printed with 2-space indent (matches Anthropic's
+ * sample configs) and trailing newline.
+ */
+export function renderMcpServersJson(cfg: SnippetConfig): string {
+  const doc = {
+    mcpServers: {
+      'discord-mcp': renderServerEntry(cfg),
+    },
+  };
+  return `${JSON.stringify(doc, null, 2)}\n`;
+}

--- a/packages/mcp-server/src/lib/client-snippets/claude-code.test.ts
+++ b/packages/mcp-server/src/lib/client-snippets/claude-code.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { claudeCodeGenerator } from './claude-code.js';
+import type { SnippetConfig } from './types.js';
+
+const baseConfig: SnippetConfig = {
+  serverPath: 'npx',
+  serverArgs: ['@discord-mcp/cli'],
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: this IS the literal placeholder syntax used by MCP clients
+  discordToken: '${env:DISCORD_TOKEN}',
+};
+
+interface ParsedDoc {
+  mcpServers: {
+    'discord-mcp': {
+      command: string;
+      args: string[];
+      env: Record<string, string>;
+    };
+  };
+}
+
+function parseSnippet(content: string): ParsedDoc {
+  return JSON.parse(content) as ParsedDoc;
+}
+
+describe('claudeCodeGenerator', () => {
+  it('exposes id and displayName', () => {
+    expect(claudeCodeGenerator.id).toBe('claude-code');
+    expect(claudeCodeGenerator.displayName).toBe('Claude Code');
+  });
+
+  it('generates parseable JSON with same shape as Claude Desktop', () => {
+    const snippet = claudeCodeGenerator.generate(baseConfig);
+    expect(snippet.format).toBe('json');
+    const parsed = parseSnippet(snippet.content);
+    expect(parsed.mcpServers).toBeDefined();
+    expect(parsed.mcpServers['discord-mcp']).toBeDefined();
+  });
+
+  it('places token in env.DISCORD_TOKEN', () => {
+    const snippet = claudeCodeGenerator.generate(baseConfig);
+    const env = parseSnippet(snippet.content).mcpServers['discord-mcp'].env;
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder, not JS interpolation
+    expect(env.DISCORD_TOKEN).toBe('${env:DISCORD_TOKEN}');
+  });
+
+  it('handles npx-style serverPath/args', () => {
+    const snippet = claudeCodeGenerator.generate(baseConfig);
+    const parsed = parseSnippet(snippet.content);
+    expect(parsed.mcpServers['discord-mcp'].command).toBe('npx');
+    expect(parsed.mcpServers['discord-mcp'].args).toEqual(['@discord-mcp/cli']);
+  });
+
+  it('appends --gateway to args when gateway: true', () => {
+    const snippet = claudeCodeGenerator.generate({ ...baseConfig, gateway: true });
+    const args = parseSnippet(snippet.content).mcpServers['discord-mcp'].args;
+    expect(args).toEqual(['@discord-mcp/cli', '--gateway']);
+  });
+
+  it('configFilePath is non-empty and mentions ~/.claude.json', () => {
+    const snippet = claudeCodeGenerator.generate(baseConfig);
+    expect(snippet.configFilePath.length).toBeGreaterThan(0);
+    expect(snippet.configFilePath).toContain('.claude.json');
+  });
+
+  it('instructions reference `claude mcp add`', () => {
+    const snippet = claudeCodeGenerator.generate(baseConfig);
+    expect(snippet.instructions).toContain('claude mcp add');
+  });
+});

--- a/packages/mcp-server/src/lib/client-snippets/claude-code.ts
+++ b/packages/mcp-server/src/lib/client-snippets/claude-code.ts
@@ -1,0 +1,36 @@
+/**
+ * Claude Code (Anthropic CLI) MCP server snippet generator.
+ *
+ * Claude Code uses the same `mcpServers` JSON schema as Claude Desktop
+ * but stores it in different locations and exposes a `claude mcp add`
+ * subcommand for managed configuration. We emit the JSON snippet for
+ * users who prefer manual editing and document both options.
+ *
+ * Path order matches Anthropic CLI's lookup: project-local takes
+ * priority over user-level. We document the user-level path here since
+ * `init` is typically run once per machine.
+ */
+import { renderMcpServersJson } from './_shared.js';
+import type { ClientGenerator, Snippet, SnippetConfig } from './types.js';
+
+const CONFIG_PATH = [
+  'User-level (preferred):  ~/.claude.json',
+  'Project-level:           <project>/.mcp.json',
+  'Modern CLI form:         claude mcp add discord-mcp -- <command> [args...]',
+].join('\n');
+
+const INSTRUCTIONS =
+  'Easiest: `claude mcp add discord-mcp -- <command> [args...]`. Manual: merge into the `mcpServers` object in ~/.claude.json (or the project-level .mcp.json).';
+
+export const claudeCodeGenerator: ClientGenerator = {
+  id: 'claude-code',
+  displayName: 'Claude Code',
+  generate(cfg: SnippetConfig): Snippet {
+    return {
+      format: 'json',
+      content: renderMcpServersJson(cfg),
+      configFilePath: CONFIG_PATH,
+      instructions: INSTRUCTIONS,
+    };
+  },
+};

--- a/packages/mcp-server/src/lib/client-snippets/claude-desktop.test.ts
+++ b/packages/mcp-server/src/lib/client-snippets/claude-desktop.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { claudeDesktopGenerator } from './claude-desktop.js';
+import type { SnippetConfig } from './types.js';
+
+const baseConfig: SnippetConfig = {
+  serverPath: '/usr/local/bin/node',
+  serverArgs: ['/abs/path/to/cli.js'],
+  discordToken: 'Bot abc123',
+};
+
+interface ParsedDoc {
+  mcpServers: {
+    'discord-mcp': {
+      command: string;
+      args: string[];
+      env: Record<string, string>;
+    };
+  };
+}
+
+function parseSnippet(content: string): ParsedDoc {
+  return JSON.parse(content) as ParsedDoc;
+}
+
+describe('claudeDesktopGenerator', () => {
+  it('exposes id and displayName', () => {
+    expect(claudeDesktopGenerator.id).toBe('claude-desktop');
+    expect(claudeDesktopGenerator.displayName).toBe('Claude Desktop');
+  });
+
+  it('generates parseable JSON', () => {
+    const snippet = claudeDesktopGenerator.generate(baseConfig);
+    expect(snippet.format).toBe('json');
+    expect(() => parseSnippet(snippet.content)).not.toThrow();
+  });
+
+  it('places token in env.DISCORD_TOKEN', () => {
+    const snippet = claudeDesktopGenerator.generate(baseConfig);
+    const parsed = parseSnippet(snippet.content);
+    expect(parsed.mcpServers['discord-mcp'].env.DISCORD_TOKEN).toBe('Bot abc123');
+  });
+
+  it('places serverPath in command and serverArgs in args', () => {
+    const snippet = claudeDesktopGenerator.generate(baseConfig);
+    const parsed = parseSnippet(snippet.content);
+    expect(parsed.mcpServers['discord-mcp'].command).toBe('/usr/local/bin/node');
+    expect(parsed.mcpServers['discord-mcp'].args).toEqual(['/abs/path/to/cli.js']);
+  });
+
+  it('appends --gateway when gateway: true', () => {
+    const snippet = claudeDesktopGenerator.generate({ ...baseConfig, gateway: true });
+    const parsed = parseSnippet(snippet.content);
+    expect(parsed.mcpServers['discord-mcp'].args).toContain('--gateway');
+  });
+
+  it('omits --gateway when gateway is false or unset', () => {
+    const noGateway = claudeDesktopGenerator.generate({ ...baseConfig, gateway: false });
+    expect(parseSnippet(noGateway.content).mcpServers['discord-mcp'].args).not.toContain(
+      '--gateway',
+    );
+    const omitted = claudeDesktopGenerator.generate(baseConfig);
+    expect(parseSnippet(omitted.content).mcpServers['discord-mcp'].args).not.toContain('--gateway');
+  });
+
+  it('merges extra envVars alongside DISCORD_TOKEN', () => {
+    const snippet = claudeDesktopGenerator.generate({
+      ...baseConfig,
+      envVars: { OTEL_ENABLED: 'true', MCP_AUDIT_SINK: 'stderr' },
+    });
+    const env = parseSnippet(snippet.content).mcpServers['discord-mcp'].env;
+    expect(env.DISCORD_TOKEN).toBe('Bot abc123');
+    expect(env.OTEL_ENABLED).toBe('true');
+    expect(env.MCP_AUDIT_SINK).toBe('stderr');
+  });
+
+  it('configFilePath is non-empty and mentions all three OSes', () => {
+    const snippet = claudeDesktopGenerator.generate(baseConfig);
+    expect(snippet.configFilePath.length).toBeGreaterThan(0);
+    expect(snippet.configFilePath).toContain('macOS');
+    expect(snippet.configFilePath).toContain('Windows');
+    expect(snippet.configFilePath).toContain('Linux');
+  });
+
+  it('instructions reference Claude Desktop and restarting', () => {
+    const snippet = claudeDesktopGenerator.generate(baseConfig);
+    expect(snippet.instructions).toMatch(/Claude Desktop/i);
+    expect(snippet.instructions.toLowerCase()).toContain('restart');
+  });
+
+  it('content ends with a trailing newline', () => {
+    const snippet = claudeDesktopGenerator.generate(baseConfig);
+    expect(snippet.content.endsWith('\n')).toBe(true);
+  });
+});

--- a/packages/mcp-server/src/lib/client-snippets/claude-desktop.ts
+++ b/packages/mcp-server/src/lib/client-snippets/claude-desktop.ts
@@ -1,0 +1,33 @@
+/**
+ * Claude Desktop MCP server snippet generator.
+ *
+ * Claude Desktop reads `mcpServers` from a JSON file. The path differs
+ * by OS; we document all three so users on any platform can find it.
+ *
+ * Restart Claude Desktop after editing — the file is read once at app
+ * startup and not watched.
+ */
+import { renderMcpServersJson } from './_shared.js';
+import type { ClientGenerator, Snippet, SnippetConfig } from './types.js';
+
+const CONFIG_PATH = [
+  'macOS:   ~/Library/Application Support/Claude/claude_desktop_config.json',
+  'Windows: %APPDATA%\\Claude\\claude_desktop_config.json',
+  'Linux:   ~/.config/Claude/claude_desktop_config.json',
+].join('\n');
+
+const INSTRUCTIONS =
+  'Merge into your existing `mcpServers` object in claude_desktop_config.json (paths above), then fully restart Claude Desktop.';
+
+export const claudeDesktopGenerator: ClientGenerator = {
+  id: 'claude-desktop',
+  displayName: 'Claude Desktop',
+  generate(cfg: SnippetConfig): Snippet {
+    return {
+      format: 'json',
+      content: renderMcpServersJson(cfg),
+      configFilePath: CONFIG_PATH,
+      instructions: INSTRUCTIONS,
+    };
+  },
+};

--- a/packages/mcp-server/src/lib/client-snippets/cursor.test.ts
+++ b/packages/mcp-server/src/lib/client-snippets/cursor.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { cursorGenerator } from './cursor.js';
+import type { SnippetConfig } from './types.js';
+
+const baseConfig: SnippetConfig = {
+  serverPath: '/usr/local/bin/discord-mcp',
+  discordToken: 'Bot xyz',
+};
+
+interface ParsedDoc {
+  mcpServers: {
+    'discord-mcp': {
+      command: string;
+      args: string[];
+      env: Record<string, string>;
+    };
+  };
+}
+
+function parseSnippet(content: string): ParsedDoc {
+  return JSON.parse(content) as ParsedDoc;
+}
+
+describe('cursorGenerator', () => {
+  it('exposes id and displayName', () => {
+    expect(cursorGenerator.id).toBe('cursor');
+    expect(cursorGenerator.displayName).toBe('Cursor');
+  });
+
+  it('generates parseable JSON', () => {
+    const snippet = cursorGenerator.generate(baseConfig);
+    expect(() => parseSnippet(snippet.content)).not.toThrow();
+  });
+
+  it('places token in env.DISCORD_TOKEN', () => {
+    const snippet = cursorGenerator.generate(baseConfig);
+    const env = parseSnippet(snippet.content).mcpServers['discord-mcp'].env;
+    expect(env.DISCORD_TOKEN).toBe('Bot xyz');
+  });
+
+  it('places serverPath in command and yields empty args without serverArgs', () => {
+    const snippet = cursorGenerator.generate(baseConfig);
+    const parsed = parseSnippet(snippet.content);
+    expect(parsed.mcpServers['discord-mcp'].command).toBe('/usr/local/bin/discord-mcp');
+    expect(parsed.mcpServers['discord-mcp'].args).toEqual([]);
+  });
+
+  it('adds --gateway when gateway: true (only arg in this scenario)', () => {
+    const snippet = cursorGenerator.generate({ ...baseConfig, gateway: true });
+    const args = parseSnippet(snippet.content).mcpServers['discord-mcp'].args;
+    expect(args).toEqual(['--gateway']);
+  });
+
+  it('configFilePath mentions both global and per-project paths', () => {
+    const snippet = cursorGenerator.generate(baseConfig);
+    expect(snippet.configFilePath).toContain('.cursor/mcp.json');
+    expect(snippet.configFilePath.toLowerCase()).toContain('global');
+    expect(snippet.configFilePath.toLowerCase()).toContain('per-project');
+  });
+
+  it('instructions reference Cursor and restart', () => {
+    const snippet = cursorGenerator.generate(baseConfig);
+    expect(snippet.instructions).toMatch(/Cursor/i);
+    expect(snippet.instructions.toLowerCase()).toContain('restart');
+  });
+});

--- a/packages/mcp-server/src/lib/client-snippets/cursor.ts
+++ b/packages/mcp-server/src/lib/client-snippets/cursor.ts
@@ -1,0 +1,31 @@
+/**
+ * Cursor MCP server snippet generator.
+ *
+ * Cursor adopted the standard `mcpServers` schema. Two scopes are
+ * supported: global (`~/.cursor/mcp.json`) and per-project
+ * (`<project>/.cursor/mcp.json`). The schema is identical, only the
+ * file location differs. Restart Cursor after editing.
+ */
+import { renderMcpServersJson } from './_shared.js';
+import type { ClientGenerator, Snippet, SnippetConfig } from './types.js';
+
+const CONFIG_PATH = [
+  'Global:           ~/.cursor/mcp.json',
+  'Per-project:      <project>/.cursor/mcp.json',
+].join('\n');
+
+const INSTRUCTIONS =
+  'Place under `~/.cursor/mcp.json` for global access, or `.cursor/mcp.json` in your project root for per-project. Restart Cursor for changes to take effect.';
+
+export const cursorGenerator: ClientGenerator = {
+  id: 'cursor',
+  displayName: 'Cursor',
+  generate(cfg: SnippetConfig): Snippet {
+    return {
+      format: 'json',
+      content: renderMcpServersJson(cfg),
+      configFilePath: CONFIG_PATH,
+      instructions: INSTRUCTIONS,
+    };
+  },
+};

--- a/packages/mcp-server/src/lib/client-snippets/generic.test.ts
+++ b/packages/mcp-server/src/lib/client-snippets/generic.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { genericGenerator } from './generic.js';
+import type { SnippetConfig } from './types.js';
+
+const baseConfig: SnippetConfig = {
+  serverPath: 'discord-mcp',
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: this IS the literal placeholder syntax used by MCP clients
+  discordToken: '${env:DISCORD_TOKEN}',
+};
+
+interface ParsedDoc {
+  mcpServers: {
+    'discord-mcp': {
+      command: string;
+      args: string[];
+      env: Record<string, string>;
+    };
+  };
+}
+
+function parseSnippet(content: string): ParsedDoc {
+  return JSON.parse(content) as ParsedDoc;
+}
+
+describe('genericGenerator', () => {
+  it('exposes id and displayName', () => {
+    expect(genericGenerator.id).toBe('generic');
+    expect(genericGenerator.displayName).toBe('Generic MCP client');
+  });
+
+  it('generates parseable JSON', () => {
+    const snippet = genericGenerator.generate(baseConfig);
+    expect(() => parseSnippet(snippet.content)).not.toThrow();
+  });
+
+  it('places token in env.DISCORD_TOKEN', () => {
+    const snippet = genericGenerator.generate(baseConfig);
+    const env = parseSnippet(snippet.content).mcpServers['discord-mcp'].env;
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder, not JS interpolation
+    expect(env.DISCORD_TOKEN).toBe('${env:DISCORD_TOKEN}');
+  });
+
+  it('places serverPath in command', () => {
+    const snippet = genericGenerator.generate(baseConfig);
+    const parsed = parseSnippet(snippet.content);
+    expect(parsed.mcpServers['discord-mcp'].command).toBe('discord-mcp');
+  });
+
+  it('appends --gateway when gateway: true', () => {
+    const snippet = genericGenerator.generate({ ...baseConfig, gateway: true });
+    const args = parseSnippet(snippet.content).mcpServers['discord-mcp'].args;
+    expect(args).toContain('--gateway');
+  });
+
+  it('configFilePath is non-empty (no specific path)', () => {
+    const snippet = genericGenerator.generate(baseConfig);
+    expect(snippet.configFilePath.length).toBeGreaterThan(0);
+  });
+
+  it('instructions reference standard MCP server config', () => {
+    const snippet = genericGenerator.generate(baseConfig);
+    expect(snippet.instructions.toLowerCase()).toContain('mcp');
+  });
+});

--- a/packages/mcp-server/src/lib/client-snippets/generic.ts
+++ b/packages/mcp-server/src/lib/client-snippets/generic.ts
@@ -1,0 +1,28 @@
+/**
+ * Generic MCP client snippet generator.
+ *
+ * Catch-all for clients that aren't first-class supported here but
+ * implement the standard MCP server config schema. We emit the same
+ * JSON shape with no client-specific path and direct the user to their
+ * client's docs for placement.
+ */
+import { renderMcpServersJson } from './_shared.js';
+import type { ClientGenerator, Snippet, SnippetConfig } from './types.js';
+
+const CONFIG_PATH = '(check your MCP client docs for the config file location)';
+
+const INSTRUCTIONS =
+  "This is the standard MCP server config block. Place it under your client's `mcpServers` object as documented by the client.";
+
+export const genericGenerator: ClientGenerator = {
+  id: 'generic',
+  displayName: 'Generic MCP client',
+  generate(cfg: SnippetConfig): Snippet {
+    return {
+      format: 'json',
+      content: renderMcpServersJson(cfg),
+      configFilePath: CONFIG_PATH,
+      instructions: INSTRUCTIONS,
+    };
+  },
+};

--- a/packages/mcp-server/src/lib/client-snippets/index.ts
+++ b/packages/mcp-server/src/lib/client-snippets/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Registry of all supported MCP client snippet generators — Plan 9 Phase D.
+ *
+ * Order is intentional: Claude Desktop first (most common entry point
+ * for new users), Claude Code second (Anthropic CLI), Cursor third
+ * (next-most-popular MCP host), Generic last (fallback). The numeric
+ * order also drives the default index in interactive `init` choice
+ * prompts.
+ *
+ * To add a new client: implement {@link ClientGenerator} in a new file
+ * under this directory, register the singleton here, and add a test.
+ * No other surface needs to change — `init` reads from this array.
+ */
+import { claudeCodeGenerator } from './claude-code.js';
+import { claudeDesktopGenerator } from './claude-desktop.js';
+import { cursorGenerator } from './cursor.js';
+import { genericGenerator } from './generic.js';
+import type { ClientGenerator } from './types.js';
+
+export type { ClientGenerator, Snippet, SnippetConfig } from './types.js';
+
+export const ALL_GENERATORS: readonly ClientGenerator[] = [
+  claudeDesktopGenerator,
+  claudeCodeGenerator,
+  cursorGenerator,
+  genericGenerator,
+];

--- a/packages/mcp-server/src/lib/client-snippets/types.ts
+++ b/packages/mcp-server/src/lib/client-snippets/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared types for the four MCP client snippet generators.
+ *
+ * Each generator consumes a {@link SnippetConfig} (the user's choices —
+ * server path, token, gateway flag, extra env) and emits a {@link Snippet}
+ * containing the rendered config text, the canonical filesystem path
+ * where it should land, and human-readable merge instructions.
+ *
+ * `init` collects the answers, picks the right generator from
+ * {@link ClientGenerator}.id, and either prints the snippet or writes it
+ * to the path requested by `--output`.
+ */
+
+/**
+ * User-supplied inputs to a generator.
+ *
+ * `serverPath` + `serverArgs` together form the `command` + `args` keys
+ * in the standard MCP server config (e.g. `command: "node",
+ * args: ["/abs/path/cli.js"]`). When the project is published on npm a
+ * portable alternative is `serverPath: "npx"` + `serverArgs:
+ * ["@discord-mcp/cli"]` — generators don't enforce one or the other,
+ * they just wire whatever the caller provides.
+ *
+ * `discordToken` is the literal value placed in `env.DISCORD_TOKEN`.
+ * Callers that don't want to leak a real secret should pass a
+ * placeholder like `${env:DISCORD_TOKEN}` so the user can resolve it
+ * via their shell environment.
+ *
+ * `gateway` adds `--gateway` to the args when true. `envVars` is merged
+ * into the `env` object alongside `DISCORD_TOKEN` (e.g. OTEL_*, MCP_AUDIT_*).
+ */
+export interface SnippetConfig {
+  readonly serverPath: string;
+  readonly serverArgs?: readonly string[];
+  readonly discordToken: string;
+  readonly gateway?: boolean;
+  readonly envVars?: Readonly<Record<string, string>>;
+}
+
+/**
+ * The rendered output of a generator.
+ *
+ * `format` distinguishes JSON (current — all 4 clients converged on the
+ * Anthropic MCP config schema) from TOML (reserved for future clients).
+ *
+ * `content` is the literal text the user pastes / the file `init`
+ * writes. Always ends with a newline so editors don't whine.
+ *
+ * `configFilePath` is documented (NOT auto-written by `init`) so users
+ * with non-standard install layouts can adapt. `instructions` is
+ * `details` material — printed under the summary in pretty mode.
+ */
+export interface Snippet {
+  readonly format: 'json' | 'toml';
+  readonly content: string;
+  readonly configFilePath: string;
+  readonly instructions: string;
+}
+
+/**
+ * Plug-in shape for each MCP client.
+ *
+ * `id` is the stable identifier passed via `--client <id>`. Must be
+ * kebab-case ASCII so it works across shells. `displayName` is rendered
+ * in human-facing output.
+ */
+export interface ClientGenerator {
+  readonly id: string;
+  readonly displayName: string;
+  generate(cfg: SnippetConfig): Snippet;
+}

--- a/packages/mcp-server/src/lib/migrate-adapters/hubdustry-go-mcp.test.ts
+++ b/packages/mcp-server/src/lib/migrate-adapters/hubdustry-go-mcp.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Adapter unit tests — Plan 9 Phase E.
+ *
+ * Tests run against the synthetic fixture under
+ * `packages/mcp-server/test-fixtures/hubdustry-go-mcp/`. The fixture
+ * lives outside `src/` so it isn't compiled, isn't packed (the package
+ * `files: ["dist", ...]` allowlist excludes it), and isn't lint-checked.
+ *
+ * The fixture contains 5 mcp.NewTool calls — server.files.{list,read,
+ * write} and server.deploy.{trigger,status}. The Hubdustry adapter's
+ * NAME_MAP is empty by design, so a successful run reports all 5 as
+ * unmapped.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, describe, expect, it } from 'vitest';
+import { hubdustryGoMcpAdapter } from './hubdustry-go-mcp.js';
+
+// `src/lib/migrate-adapters/hubdustry-go-mcp.test.ts` is three directories
+// below the package root, where `test-fixtures/` lives.
+const PACKAGE_ROOT = fileURLToPath(new URL('../../../', import.meta.url));
+const FIXTURE_ROOT = join(PACKAGE_ROOT, 'test-fixtures', 'hubdustry-go-mcp');
+
+describe('hubdustryGoMcpAdapter — id + description', () => {
+  it('exposes a stable kebab-case id', () => {
+    expect(hubdustryGoMcpAdapter.id).toBe('hubdustry-go-mcp');
+  });
+
+  it('has a non-empty description', () => {
+    expect(hubdustryGoMcpAdapter.description.length).toBeGreaterThan(10);
+  });
+});
+
+describe('hubdustryGoMcpAdapter — detect()', () => {
+  it('returns true for the synthetic fixture (apps/mcp layout)', async () => {
+    expect(await hubdustryGoMcpAdapter.detect(FIXTURE_ROOT)).toBe(true);
+  });
+
+  it('returns false for a path with no Hubdustry markers', async () => {
+    // Use a fresh temp dir so we're guaranteed nothing matches.
+    const empty = mkdtempSync(join(tmpdir(), 'hubdustry-detect-'));
+    try {
+      expect(await hubdustryGoMcpAdapter.detect(empty)).toBe(false);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  it('returns false for a non-existent path (does not throw)', async () => {
+    expect(await hubdustryGoMcpAdapter.detect('C:/this/path/should/not/exist/anywhere')).toBe(
+      false,
+    );
+  });
+});
+
+describe('hubdustryGoMcpAdapter — migrate()', () => {
+  it('reports all 5 fixture tools as unmappedTools (NAME_MAP is empty)', async () => {
+    const result = await hubdustryGoMcpAdapter.migrate(FIXTURE_ROOT);
+    expect(result.source).toBe('hubdustry-go-mcp');
+    expect(result.mappedTools.length).toBe(0);
+    expect(result.manualReview.length).toBe(0);
+    expect(result.unmappedTools.length).toBe(5);
+    expect(result.unmappedTools).toEqual(
+      expect.arrayContaining([
+        'server.files.list',
+        'server.files.read',
+        'server.files.write',
+        'server.deploy.trigger',
+        'server.deploy.status',
+      ]),
+    );
+  });
+
+  it('resolves apps/mcp under sourcePath when the monorepo layout is present', async () => {
+    const result = await hubdustryGoMcpAdapter.migrate(FIXTURE_ROOT);
+    expect(result.sourcePath).toBe(join(FIXTURE_ROOT, 'apps', 'mcp'));
+  });
+
+  it('emits a "no mcp.NewTool calls found" warning for an empty dir', async () => {
+    const empty = mkdtempSync(join(tmpdir(), 'hubdustry-migrate-empty-'));
+    try {
+      const result = await hubdustryGoMcpAdapter.migrate(empty);
+      expect(result.unmappedTools.length).toBe(0);
+      expect(result.warnings.some((w) => w.includes('no mcp.NewTool'))).toBe(true);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  it('walks tools/*.go recursively (subdir tools also discovered)', async () => {
+    // Sanity: the fixture's tools/ has flat files, so the recursion just
+    // confirms the readDirGoFiles helper visits them. Both files.go and
+    // deploy.go are read — verified via the per-tool count below.
+    const result = await hubdustryGoMcpAdapter.migrate(FIXTURE_ROOT);
+    const fileTools = result.unmappedTools.filter((n) => n.startsWith('server.files.'));
+    const deployTools = result.unmappedTools.filter((n) => n.startsWith('server.deploy.'));
+    expect(fileTools.length).toBe(3);
+    expect(deployTools.length).toBe(2);
+  });
+
+  // Defensive cleanup in case any test left a temp dir behind.
+  afterAll(() => {
+    // No persistent state to clean here — temp dirs are scoped per-test.
+  });
+});

--- a/packages/mcp-server/src/lib/migrate-adapters/hubdustry-go-mcp.ts
+++ b/packages/mcp-server/src/lib/migrate-adapters/hubdustry-go-mcp.ts
@@ -1,0 +1,166 @@
+/**
+ * Hubdustry Go MCP adapter — Plan 9 Phase E reference implementation.
+ *
+ * Hubdustry's MCP server (https://github.com/jhm1909/Hubdustry/tree/main/apps/mcp)
+ * was the user's previous Go-based project. Its tools are all
+ * server-admin / files / containers / deploy / system-stats — none are
+ * Discord — so against a real Hubdustry tree this adapter produces
+ * `0 mapped, N unmapped, 0 manual review`. That's the intended output:
+ * it demonstrates the framework while honestly reporting that Hubdustry
+ * has nothing this MCP can run today. Plan 11 ships Discord-using
+ * adapters with real mappings.
+ *
+ * Detection strategy: look for `apps/mcp/main.go` or a top-level
+ * `main.go` and read it; if either contains `hubdustry` or the
+ * `mcp.NewTool` call pattern we consider this a Hubdustry-shaped repo.
+ *
+ * Tool extraction: regex over `*.go` files under `tools/` for the
+ * `mcp.NewTool("name"` pattern. This is best-effort — it will miss
+ * multi-line calls and any tool name built via concatenation. The
+ * adapter is documented to be best-effort; users can extend or
+ * hand-edit the result.
+ */
+import type { Dirent } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import type { MigrationResult, MigrationSource } from './types.js';
+
+/**
+ * Hubdustry tool name → discord-mcp tool name. Empty by design: every
+ * Hubdustry tool is non-Discord. Future Hubdustry forks that DO use
+ * Discord (or a Hubdustry rewrite that adds Discord-bot tools) would
+ * populate entries here.
+ */
+const NAME_MAP: Record<string, string> = {
+  // intentionally empty — see file-level JSDoc.
+};
+
+/**
+ * Resolve the actual Hubdustry root: prefer `<rootPath>/apps/mcp` (the
+ * monorepo layout the user runs locally), fall back to `<rootPath>`
+ * itself (a standalone clone of just the mcp app). Returns the
+ * unchanged `rootPath` if neither candidate has a `main.go` — `migrate`
+ * then proceeds and reports "no tools found" via `warnings`.
+ */
+function detectActualPath(rootPath: string): string {
+  const monorepoCandidate = join(rootPath, 'apps', 'mcp');
+  try {
+    statSync(join(monorepoCandidate, 'main.go'));
+    return monorepoCandidate;
+  } catch {
+    // not the monorepo layout — try the direct layout below.
+  }
+  try {
+    statSync(join(rootPath, 'main.go'));
+    return rootPath;
+  } catch {
+    // neither found — let migrate() report empty results.
+  }
+  return rootPath;
+}
+
+/**
+ * Recursively list `*.go` files under `dir` (excluding `_test.go`).
+ * Returns an empty array if `dir` is missing or unreadable.
+ */
+function readDirGoFiles(dir: string): string[] {
+  const out: string[] = [];
+  let entries: Dirent[];
+  try {
+    // Force string-mode Dirent. The default overload picks `Buffer` when
+    // tsc can't narrow the encoding from the args alone (Node 22 types).
+    entries = readdirSync(dir, { withFileTypes: true, encoding: 'utf8' }) as Dirent[];
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const name = entry.name;
+    const full = join(dir, name);
+    if (entry.isDirectory()) {
+      out.push(...readDirGoFiles(full));
+    } else if (entry.isFile() && name.endsWith('.go') && !name.endsWith('_test.go')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+export const hubdustryGoMcpAdapter: MigrationSource = {
+  id: 'hubdustry-go-mcp',
+  description: 'Hubdustry Go MCP server (apps/mcp) — non-Discord tools, reference adapter',
+
+  async detect(rootPath: string): Promise<boolean> {
+    const candidates = [join(rootPath, 'main.go'), join(rootPath, 'apps', 'mcp', 'main.go')];
+    for (const path of candidates) {
+      try {
+        statSync(path);
+        const content = readFileSync(path, 'utf8');
+        if (content.includes('hubdustry') || content.includes('mcp.NewTool')) {
+          return true;
+        }
+      } catch {
+        // file missing or unreadable — try the next candidate.
+      }
+    }
+    return false;
+  },
+
+  async migrate(rootPath: string): Promise<MigrationResult> {
+    const sourcePath = detectActualPath(rootPath);
+    const toolsDir = join(sourcePath, 'tools');
+
+    const allTools: string[] = [];
+    const warnings: string[] = [];
+
+    const files = readDirGoFiles(toolsDir);
+    for (const file of files) {
+      let content: string;
+      try {
+        content = readFileSync(file, 'utf8');
+      } catch (e) {
+        warnings.push(`could not read ${file}: ${e instanceof Error ? e.message : String(e)}`);
+        continue;
+      }
+      // Best-effort: matches `mcp.NewTool("tool.name"` on a single line.
+      // Multi-line calls or concatenated names will be missed.
+      const re = /mcp\.NewTool\s*\(\s*"([^"]+)"/g;
+      for (const match of content.matchAll(re)) {
+        const name = match[1];
+        if (name !== undefined && !allTools.includes(name)) {
+          allTools.push(name);
+        }
+      }
+    }
+
+    if (allTools.length === 0) {
+      warnings.push('no mcp.NewTool calls found — adapter may not match this Hubdustry version');
+    }
+
+    const mappedTools = allTools
+      .filter((name) => NAME_MAP[name] !== undefined)
+      .map((name) => {
+        const mapped = NAME_MAP[name];
+        // NAME_MAP[name] is non-undefined per the filter; assert via local.
+        if (mapped === undefined) {
+          // unreachable, but the type narrowing requires this branch.
+          throw new Error(`unreachable: ${name} passed filter but NAME_MAP returned undefined`);
+        }
+        return {
+          original: name,
+          mapped,
+          confidence: 'high' as const,
+        };
+      });
+
+    const unmappedTools = allTools.filter((name) => NAME_MAP[name] === undefined);
+
+    return {
+      source: 'hubdustry-go-mcp',
+      sourcePath,
+      mappedTools,
+      unmappedTools,
+      manualReview: [],
+      warnings,
+    };
+  },
+};

--- a/packages/mcp-server/src/lib/migrate-adapters/index.ts
+++ b/packages/mcp-server/src/lib/migrate-adapters/index.ts
@@ -12,10 +12,11 @@
  * will add Discord-using adapters (PaSympa, quadslab, discord-ops,
  * barryyip).
  */
+import { hubdustryGoMcpAdapter } from './hubdustry-go-mcp.js';
 import type { MigrationSource } from './types.js';
 
 export const ALL_ADAPTERS: readonly MigrationSource[] = [
-  // E.2 adds the Hubdustry adapter as the first reference implementation.
+  hubdustryGoMcpAdapter,
   // Plan 11 adds: paSympaAdapter, quadslabAdapter, discordOpsAdapter, barryyipAdapter
 ];
 

--- a/packages/mcp-server/src/lib/migrate-adapters/index.ts
+++ b/packages/mcp-server/src/lib/migrate-adapters/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Registry of all known migration adapters — Plan 9 Phase E.
+ *
+ * `migrate` reads this array exclusively; no other module imports an
+ * adapter implementation directly. To add a new source: implement
+ * {@link MigrationSource} in a new file under this directory, register
+ * the singleton here, and add a test.
+ *
+ * Phase E ships only the Hubdustry adapter as a reference implementation
+ * (its tools are non-Discord — intentionally produces "0 mapped, 8
+ * unmapped, 0 manual review" against a real Hubdustry tree). Plan 11
+ * will add Discord-using adapters (PaSympa, quadslab, discord-ops,
+ * barryyip).
+ */
+import type { MigrationSource } from './types.js';
+
+export const ALL_ADAPTERS: readonly MigrationSource[] = [
+  // E.2 adds the Hubdustry adapter as the first reference implementation.
+  // Plan 11 adds: paSympaAdapter, quadslabAdapter, discordOpsAdapter, barryyipAdapter
+];
+
+export type {
+  ManualReviewItem,
+  MappedTool,
+  MigrationResult,
+  MigrationSource,
+} from './types.js';

--- a/packages/mcp-server/src/lib/migrate-adapters/types.ts
+++ b/packages/mcp-server/src/lib/migrate-adapters/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Migration adapter pattern — Plan 9 Phase E.
+ *
+ * A {@link MigrationSource} represents one supported "source" project
+ * shape (e.g. the Hubdustry Go MCP server, a legacy discord-bot config).
+ * Each adapter knows how to:
+ *
+ *   1. {@link MigrationSource.detect} — answer "is this filesystem a
+ *      project I understand?" without throwing on missing files.
+ *   2. {@link MigrationSource.migrate} — walk the source tree and emit
+ *      a {@link MigrationResult} listing tools mapped onto discord-mcp,
+ *      tools that have no equivalent yet (`unmappedTools`), and items
+ *      that need a human eye (`manualReview`).
+ *
+ * The `migrate` command iterates this pattern: it never imports an
+ * adapter implementation directly — it only consumes the registry in
+ * `./index.ts`. Plan 11 will add Discord-using adapters
+ * (PaSympa / quadslab / discord-ops / barryyip) without touching this
+ * type or the command surface.
+ */
+
+/**
+ * One supported source project shape.
+ *
+ * Adapters are pure: `detect` and `migrate` MUST NOT mutate the
+ * filesystem under `rootPath` and MUST NOT spawn child processes.
+ * They are allowed to read files and walk directories.
+ */
+export interface MigrationSource {
+  /** Stable kebab-case identifier passed via `--from <id>`. */
+  readonly id: string;
+  /** Single-line human-readable description shown in `--help` listing. */
+  readonly description: string;
+  /**
+   * Return true if `rootPath` looks like this kind of source. MUST NOT
+   * throw — wrap fs ops in try/catch and return false on missing paths.
+   */
+  detect(rootPath: string): Promise<boolean>;
+  /**
+   * Walk the source tree and produce a {@link MigrationResult}. May
+   * surface non-fatal issues via `warnings`; throw only on truly
+   * unrecoverable IO errors (the caller turns those into exit code 2).
+   */
+  migrate(rootPath: string): Promise<MigrationResult>;
+}
+
+/**
+ * One source tool successfully mapped onto a discord-mcp equivalent.
+ *
+ * `confidence` is the adapter's self-assessment:
+ *   - `high`   — name + arg shape are a 1:1 match.
+ *   - `medium` — name matches but args may need tweaking.
+ *   - `low`    — best-guess; user MUST verify.
+ */
+export interface MappedTool {
+  readonly original: string;
+  readonly mapped: string;
+  readonly confidence: 'high' | 'medium' | 'low';
+  readonly notes?: string;
+}
+
+/**
+ * One source tool that the adapter recognised but couldn't auto-map.
+ * The `reason` explains why and `suggestion` (if any) names the
+ * discord-mcp tool a human should look at first.
+ */
+export interface ManualReviewItem {
+  readonly original: string;
+  readonly reason: string;
+  readonly suggestion?: string;
+}
+
+/**
+ * Result of running an adapter against a source path.
+ *
+ * `mappedTools` + `unmappedTools` + `manualReview` sum to the total
+ * number of source tools the adapter found. `unmappedTools` is allowed
+ * to be non-empty — that's still a valid run (exit code 1, not 2).
+ *
+ * `warnings` carries non-blocking notices (e.g. "no tools found in
+ * fixture", "regex may have missed multi-line calls").
+ */
+export interface MigrationResult {
+  readonly source: string;
+  readonly sourcePath: string;
+  readonly mappedTools: readonly MappedTool[];
+  readonly unmappedTools: readonly string[];
+  readonly manualReview: readonly ManualReviewItem[];
+  readonly warnings: readonly string[];
+}

--- a/packages/mcp-server/src/lib/output.test.ts
+++ b/packages/mcp-server/src/lib/output.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type CommandResult, emitResult } from './output.js';
+
+const originalIsTTY = process.stdout.isTTY;
+const originalExitCode = process.exitCode;
+
+const writes: string[] = [];
+
+beforeEach(() => {
+  writes.length = 0;
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown): boolean => {
+    writes.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value: originalIsTTY,
+    configurable: true,
+    writable: true,
+  });
+  process.exitCode = originalExitCode;
+});
+
+function lastWrite(): string {
+  if (writes.length === 0) {
+    throw new Error('emitResult did not write to stdout');
+  }
+  return writes[0] ?? '';
+}
+
+function setTTY(value: boolean): void {
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+// CSI byte = ESC + '['. We assert presence/absence by substring instead
+// of a regex (biome's noControlCharactersInRegex disallows \x1b literals).
+const CSI_BYTE = '\x1b[';
+function hasAnsi(s: string): boolean {
+  return s.includes(CSI_BYTE);
+}
+
+describe('emitResult — JSON mode', () => {
+  it('produces parseable JSON for an ok result', () => {
+    const result: CommandResult = {
+      ok: true,
+      summary: 'all green',
+      exitCode: 0,
+    };
+    emitResult(result, true);
+
+    const out = lastWrite();
+    const parsed = JSON.parse(out);
+    expect(parsed).toEqual(result);
+    expect(out.endsWith('\n')).toBe(true);
+  });
+
+  it('strips color codes in JSON mode even on TTY', () => {
+    setTTY(true);
+    const result: CommandResult = {
+      ok: false,
+      summary: 'nope',
+      errors: ['boom'],
+      exitCode: 2,
+    };
+    emitResult(result, true);
+
+    const out = lastWrite();
+    expect(hasAnsi(out)).toBe(false);
+    // Still parseable.
+    expect(() => JSON.parse(out)).not.toThrow();
+  });
+
+  it('echoes data payload', () => {
+    const result: CommandResult = {
+      ok: true,
+      summary: 'done',
+      data: { tools: 192, transport: 'stdio' },
+      exitCode: 0,
+    };
+    emitResult(result, true);
+
+    const parsed = JSON.parse(lastWrite()) as CommandResult;
+    expect(parsed.data).toEqual({ tools: 192, transport: 'stdio' });
+  });
+});
+
+describe('emitResult — pretty TTY mode', () => {
+  it('includes color codes when stdout.isTTY is true', () => {
+    setTTY(true);
+    const result: CommandResult = {
+      ok: true,
+      summary: 'all green',
+      exitCode: 0,
+    };
+    emitResult(result, false);
+
+    const out = lastWrite();
+    expect(hasAnsi(out)).toBe(true);
+    expect(out).toContain('OK');
+    expect(out).toContain('all green');
+  });
+
+  it('omits color codes when stdout.isTTY is false', () => {
+    setTTY(false);
+    const result: CommandResult = {
+      ok: true,
+      summary: 'all green',
+      exitCode: 0,
+    };
+    emitResult(result, false);
+
+    const out = lastWrite();
+    expect(hasAnsi(out)).toBe(false);
+    expect(out).toContain('OK all green');
+  });
+
+  it('formats warnings as bullet list', () => {
+    setTTY(false);
+    const result: CommandResult = {
+      ok: false,
+      summary: '2 warnings',
+      warnings: ['no token', 'gateway disabled'],
+      exitCode: 1,
+    };
+    emitResult(result, false);
+
+    const out = lastWrite();
+    expect(out).toContain('Warnings:');
+    expect(out).toContain('* no token');
+    expect(out).toContain('* gateway disabled');
+    expect(out).toContain('WARN');
+  });
+
+  it('formats errors as bullet list', () => {
+    setTTY(false);
+    const result: CommandResult = {
+      ok: false,
+      summary: 'check failed',
+      errors: ['bad token', 'rate limited'],
+      exitCode: 2,
+    };
+    emitResult(result, false);
+
+    const out = lastWrite();
+    expect(out).toContain('Errors:');
+    expect(out).toContain('* bad token');
+    expect(out).toContain('* rate limited');
+    expect(out).toContain('FAIL');
+  });
+
+  it('renders details under summary', () => {
+    setTTY(false);
+    const result: CommandResult = {
+      ok: true,
+      summary: 'doctor',
+      details: ['token: ok', 'gateway: skipped'],
+      exitCode: 0,
+    };
+    emitResult(result, false);
+
+    const out = lastWrite();
+    expect(out).toContain('token: ok');
+    expect(out).toContain('gateway: skipped');
+  });
+});
+
+describe('emitResult — exit code', () => {
+  it('sets process.exitCode to 0 for ok', () => {
+    emitResult({ ok: true, summary: 'ok', exitCode: 0 }, true);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('sets process.exitCode to 1 for warn', () => {
+    emitResult({ ok: false, summary: 'warn', warnings: ['x'], exitCode: 1 }, true);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('sets process.exitCode to 2 for error', () => {
+    emitResult({ ok: false, summary: 'fail', errors: ['x'], exitCode: 2 }, true);
+    expect(process.exitCode).toBe(2);
+  });
+
+  it('does not call process.exit', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit called with ${code}`);
+    }) as never);
+    try {
+      emitResult({ ok: false, summary: 'x', errors: ['x'], exitCode: 2 }, false);
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+});

--- a/packages/mcp-server/src/lib/output.ts
+++ b/packages/mcp-server/src/lib/output.ts
@@ -1,0 +1,112 @@
+/**
+ * CLI output formatter — pretty TTY mode and JSON mode.
+ *
+ * Plan 9 Phase A. The output module is shared by `doctor`, `init`,
+ * `migrate` and any future sub-command that emits a structured result.
+ *
+ * Rules (per plan §3.3 / §A.1):
+ * - JSON mode is non-negotiable: when `asJson === true` we MUST NOT
+ *   emit any ANSI color codes regardless of TTY status. JSON output
+ *   has to be parseable by downstream tooling.
+ * - Pretty TTY mode uses manual ANSI escapes (zero new deps).
+ * - We never call `process.exit()`. Instead we set `process.exitCode`
+ *   so Node drains stdout/stderr naturally before exiting. The single
+ *   exception (`serve`) is documented in commands/serve.ts.
+ */
+
+/**
+ * Structured result emitted by a CLI sub-command.
+ *
+ * `ok`: terminal success/failure (true when exitCode === 0).
+ * `summary`: one-line headline rendered first in pretty mode.
+ * `details`: optional multi-line context under the summary.
+ * `warnings`: non-blocking notices (exitCode 1 when no errors).
+ * `errors`: blocking failures (exitCode 2).
+ * `data`: arbitrary JSON-shaped payload echoed in JSON mode.
+ * `exitCode`: 0 ok, 1 warns, 2 errors. Caller is responsible for
+ *   choosing the right code; emitResult only sets `process.exitCode`.
+ */
+export interface CommandResult {
+  ok: boolean;
+  summary: string;
+  details?: string[];
+  warnings?: string[];
+  errors?: string[];
+  data?: Record<string, unknown>;
+  exitCode: 0 | 1 | 2;
+}
+
+// CSI introducer = ESC + '['. Written via \x1b so the source stays
+// grep-friendly without an embedded control byte. Manual ANSI keeps
+// us at zero new runtime deps (no chalk, no picocolors).
+const CSI = '\x1b[';
+const ANSI = {
+  reset: `${CSI}0m`,
+  bold: `${CSI}1m`,
+  dim: `${CSI}2m`,
+  green: `${CSI}32m`,
+  yellow: `${CSI}33m`,
+  red: `${CSI}31m`,
+  cyan: `${CSI}36m`,
+} as const;
+
+function supportsColor(): boolean {
+  return process.stdout.isTTY === true;
+}
+
+function color(code: string, text: string, enabled: boolean): string {
+  if (!enabled) {
+    return text;
+  }
+  return `${code}${text}${ANSI.reset}`;
+}
+
+function renderPretty(result: CommandResult): string {
+  const enabled = supportsColor();
+  const lines: string[] = [];
+
+  const symbol = result.ok
+    ? color(ANSI.green, 'OK', enabled)
+    : result.exitCode === 2
+      ? color(ANSI.red, 'FAIL', enabled)
+      : color(ANSI.yellow, 'WARN', enabled);
+  lines.push(`${color(ANSI.bold, symbol, enabled)} ${result.summary}`);
+
+  if (result.details !== undefined && result.details.length > 0) {
+    for (const detail of result.details) {
+      lines.push(`  ${color(ANSI.dim, detail, enabled)}`);
+    }
+  }
+
+  if (result.warnings !== undefined && result.warnings.length > 0) {
+    lines.push('');
+    lines.push(color(ANSI.yellow, color(ANSI.bold, 'Warnings:', enabled), enabled));
+    for (const warning of result.warnings) {
+      lines.push(`  ${color(ANSI.yellow, '*', enabled)} ${warning}`);
+    }
+  }
+
+  if (result.errors !== undefined && result.errors.length > 0) {
+    lines.push('');
+    lines.push(color(ANSI.red, color(ANSI.bold, 'Errors:', enabled), enabled));
+    for (const err of result.errors) {
+      lines.push(`  ${color(ANSI.red, '*', enabled)} ${err}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * Emit a CommandResult. Sets `process.exitCode = result.exitCode`.
+ * Never calls `process.exit()` — Node drains stdout/stderr naturally
+ * once the event loop empties.
+ */
+export function emitResult(result: CommandResult, asJson: boolean): void {
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } else {
+    process.stdout.write(renderPretty(result));
+  }
+  process.exitCode = result.exitCode;
+}

--- a/packages/mcp-server/src/lib/prompt.test.ts
+++ b/packages/mcp-server/src/lib/prompt.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for the readline prompt helpers — Plan 9 Phase D.
+ *
+ * `readline.createInterface` is mocked at the module level so we can
+ * stub the `question()` method per test. Each test sets `mockAnswer` to
+ * the next return value before calling the helper.
+ *
+ * `isInteractive()` is exercised by overriding `process.stdin.isTTY` and
+ * `process.stdout.isTTY` directly.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mockAnswer = '';
+const closeMock = vi.fn();
+const questionMock = vi.fn(async (_prompt: string): Promise<string> => mockAnswer);
+
+vi.mock('node:readline/promises', () => ({
+  createInterface: vi.fn(() => ({
+    question: questionMock,
+    close: closeMock,
+  })),
+}));
+
+const { ask, askChoice, askYesNo, isInteractive } = await import('./prompt.js');
+
+const originalStdinTTY = process.stdin.isTTY;
+const originalStdoutTTY = process.stdout.isTTY;
+
+beforeEach(() => {
+  mockAnswer = '';
+  questionMock.mockClear();
+  closeMock.mockClear();
+});
+
+afterEach(() => {
+  Object.defineProperty(process.stdin, 'isTTY', {
+    value: originalStdinTTY,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value: originalStdoutTTY,
+    configurable: true,
+    writable: true,
+  });
+});
+
+function setTTY(stdin: boolean, stdout: boolean): void {
+  Object.defineProperty(process.stdin, 'isTTY', {
+    value: stdin,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value: stdout,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe('isInteractive', () => {
+  it('returns true when both stdin and stdout are TTYs', () => {
+    setTTY(true, true);
+    expect(isInteractive()).toBe(true);
+  });
+
+  it('returns false when stdin is not a TTY', () => {
+    setTTY(false, true);
+    expect(isInteractive()).toBe(false);
+  });
+
+  it('returns false when stdout is not a TTY', () => {
+    setTTY(true, false);
+    expect(isInteractive()).toBe(false);
+  });
+
+  it('returns false when neither is a TTY', () => {
+    setTTY(false, false);
+    expect(isInteractive()).toBe(false);
+  });
+
+  it('returns false when isTTY is undefined', () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    expect(isInteractive()).toBe(false);
+  });
+});
+
+describe('ask', () => {
+  it('returns trimmed user input when non-empty', async () => {
+    mockAnswer = '  hello world  ';
+    const result = await ask('say hi');
+    expect(result).toBe('hello world');
+    expect(closeMock).toHaveBeenCalled();
+  });
+
+  it('returns the default when input is empty and a default is provided', async () => {
+    mockAnswer = '';
+    const result = await ask('your name', 'anonymous');
+    expect(result).toBe('anonymous');
+  });
+
+  it('returns the default when input is whitespace-only and a default is provided', async () => {
+    mockAnswer = '   ';
+    const result = await ask('your name', 'anon');
+    expect(result).toBe('anon');
+  });
+
+  it('returns empty string when input empty and no default', async () => {
+    mockAnswer = '';
+    const result = await ask('whatever');
+    expect(result).toBe('');
+  });
+
+  it('renders the default value in the prompt label', async () => {
+    mockAnswer = 'x';
+    await ask('pick', 'foo');
+    expect(questionMock).toHaveBeenCalledWith('pick [foo]: ');
+  });
+
+  it('renders just the question when no default is provided', async () => {
+    mockAnswer = 'x';
+    await ask('pick');
+    expect(questionMock).toHaveBeenCalledWith('pick: ');
+  });
+
+  it('closes the readline interface even when question throws', async () => {
+    questionMock.mockRejectedValueOnce(new Error('boom'));
+    await expect(ask('q')).rejects.toThrow('boom');
+    expect(closeMock).toHaveBeenCalled();
+  });
+});
+
+describe('askYesNo', () => {
+  it('returns true for "y"', async () => {
+    mockAnswer = 'y';
+    expect(await askYesNo('continue?', false)).toBe(true);
+  });
+
+  it('returns true for "yes"', async () => {
+    mockAnswer = 'yes';
+    expect(await askYesNo('continue?', false)).toBe(true);
+  });
+
+  it('returns true for "Y" (case-insensitive)', async () => {
+    mockAnswer = 'Y';
+    expect(await askYesNo('continue?', false)).toBe(true);
+  });
+
+  it('returns false for "n"', async () => {
+    mockAnswer = 'n';
+    expect(await askYesNo('continue?', true)).toBe(false);
+  });
+
+  it('returns the default when input is empty (defaultYes=true)', async () => {
+    mockAnswer = '';
+    expect(await askYesNo('continue?', true)).toBe(true);
+  });
+
+  it('returns the default when input is empty (defaultYes=false)', async () => {
+    mockAnswer = '';
+    expect(await askYesNo('continue?', false)).toBe(false);
+  });
+
+  it('renders (Y/n) when defaultYes=true', async () => {
+    mockAnswer = 'y';
+    await askYesNo('continue?', true);
+    expect(questionMock).toHaveBeenCalledWith('continue? (Y/n) [y]: ');
+  });
+
+  it('renders (y/N) when defaultYes=false', async () => {
+    mockAnswer = 'y';
+    await askYesNo('continue?', false);
+    expect(questionMock).toHaveBeenCalledWith('continue? (y/N) [n]: ');
+  });
+});
+
+describe('askChoice', () => {
+  it('returns the choice for a valid 1-based index', async () => {
+    mockAnswer = '2';
+    const result = await askChoice('pick', ['a', 'b', 'c'] as const, 0);
+    expect(result).toBe('b');
+  });
+
+  it('returns the default when input is empty', async () => {
+    mockAnswer = '';
+    const result = await askChoice('pick', ['a', 'b', 'c'] as const, 1);
+    expect(result).toBe('b');
+  });
+
+  it('clamps a too-large index to the max choice', async () => {
+    mockAnswer = '99';
+    const result = await askChoice('pick', ['a', 'b', 'c'] as const, 0);
+    expect(result).toBe('c');
+  });
+
+  it('clamps a zero/negative input to the first choice', async () => {
+    mockAnswer = '0';
+    const result = await askChoice('pick', ['a', 'b', 'c'] as const, 2);
+    expect(result).toBe('a');
+  });
+
+  it('falls back to default for non-numeric input', async () => {
+    mockAnswer = 'banana';
+    const result = await askChoice('pick', ['a', 'b', 'c'] as const, 1);
+    expect(result).toBe('b');
+  });
+
+  it('renders a numbered menu with default marker', async () => {
+    mockAnswer = '1';
+    await askChoice('pick', ['x', 'y'] as const, 1);
+    const call = questionMock.mock.calls[0]?.[0] ?? '';
+    expect(call).toContain('1. x');
+    expect(call).toContain('2. y (default)');
+    expect(call).toContain('Choose 1-2');
+  });
+});

--- a/packages/mcp-server/src/lib/prompt.ts
+++ b/packages/mcp-server/src/lib/prompt.ts
@@ -1,0 +1,96 @@
+/**
+ * Tiny readline prompt helper — Plan 9 Phase D.
+ *
+ * `init` is the only sub-command (so far) that needs interactive input.
+ * Rather than pull `inquirer`/`prompts`/`enquirer` for a single command
+ * we wrap `node:readline/promises` with three thin helpers. Zero new
+ * runtime deps, zero ANSI terminal handling — Node's readline already
+ * does line editing and ^C handling for us.
+ *
+ * `isInteractive()` is the canonical TTY gate. Both `stdin` and `stdout`
+ * must be TTYs because we read user input on stdin and render the prompt
+ * on stdout. CI runners (GitHub Actions, etc.) pipe both, so this returns
+ * false there and callers must fall back to defaults / required flags.
+ *
+ * Every helper accepts a sane default so non-interactive callers can
+ * skip the prompt entirely by passing all answers via flags.
+ */
+import { stdin, stdout } from 'node:process';
+import * as readline from 'node:readline/promises';
+
+/**
+ * True iff both stdin and stdout are TTYs.
+ *
+ * When false the caller MUST NOT call `ask()` / `askYesNo()` / `askChoice()`
+ * — those would block forever on piped stdin or write garbage to a
+ * non-TTY stdout. Use the function flags / defaults instead.
+ */
+export function isInteractive(): boolean {
+  return stdin.isTTY === true && stdout.isTTY === true;
+}
+
+/**
+ * Prompt for a single line of input. If `defaultValue` is provided and
+ * the user submits an empty string, the default is returned; otherwise
+ * the trimmed input is returned.
+ *
+ * The readline interface is created and disposed per call — this keeps
+ * the helpers stateless and safe to call from anywhere.
+ */
+export async function ask(question: string, defaultValue?: string): Promise<string> {
+  const rl = readline.createInterface({ input: stdin, output: stdout });
+  try {
+    const prompt = defaultValue !== undefined ? `${question} [${defaultValue}]: ` : `${question}: `;
+    const answer = await rl.question(prompt);
+    const trimmed = answer.trim();
+    if (trimmed === '' && defaultValue !== undefined) {
+      return defaultValue;
+    }
+    return trimmed;
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Prompt for a yes/no answer. The displayed `(Y/n)` or `(y/N)` matches
+ * `defaultYes`. Any input starting with 'y' (case-insensitive) → true,
+ * otherwise → false. Empty input returns `defaultYes`.
+ */
+export async function askYesNo(question: string, defaultYes: boolean): Promise<boolean> {
+  const ans = await ask(`${question} (${defaultYes ? 'Y/n' : 'y/N'})`, defaultYes ? 'y' : 'n');
+  return ans.toLowerCase().startsWith('y');
+}
+
+/**
+ * Prompt for a choice from a fixed list. Renders as a numbered menu and
+ * accepts a 1-based index. Out-of-range / non-numeric input clamps to
+ * `defaultIndex` (which is 0-based, so it matches array indices).
+ *
+ * Generic over `T extends string` so callers preserve the literal union
+ * (e.g. `'claude-desktop' | 'cursor'`) instead of widening to `string`.
+ */
+export async function askChoice<T extends string>(
+  question: string,
+  choices: readonly T[],
+  defaultIndex: number,
+): Promise<T> {
+  const list = choices
+    .map((c, i) => `  ${i + 1}. ${c}${i === defaultIndex ? ' (default)' : ''}`)
+    .join('\n');
+  const ans = await ask(
+    `${question}\n${list}\nChoose 1-${choices.length}`,
+    String(defaultIndex + 1),
+  );
+  const parsed = Number.parseInt(ans, 10);
+  const idx =
+    Math.max(1, Math.min(choices.length, Number.isFinite(parsed) ? parsed : defaultIndex + 1)) - 1;
+  // idx is clamped into [0, choices.length-1] so the index is always defined.
+  // The non-null assertion is required because tsconfig has noUncheckedIndexedAccess.
+  const picked = choices[idx];
+  if (picked === undefined) {
+    // Defensive: clamp invariant failed (impossible given Math.max/min above).
+    throw new Error(`askChoice: clamped index ${idx} out of range [0, ${choices.length - 1}]`);
+  }
+  return picked;
+}

--- a/packages/mcp-server/test-fixtures/hubdustry-go-mcp/apps/mcp/main.go
+++ b/packages/mcp-server/test-fixtures/hubdustry-go-mcp/apps/mcp/main.go
@@ -1,0 +1,17 @@
+// FIXTURE: minimal Go for adapter testing — not real code
+// Synthetic stand-in for hubdustry/apps/mcp/main.go used by
+// hubdustry-go-mcp.test.ts. Only needs to mention `hubdustry` (or
+// the mcp.NewTool pattern) so the adapter's detect() returns true.
+package main
+
+import (
+	"fmt"
+
+	"example.com/hubdustry/mcp/tools"
+)
+
+func main() {
+	fmt.Println("hubdustry mcp fixture")
+	tools.RegisterFileTools()
+	tools.RegisterDeployTools()
+}

--- a/packages/mcp-server/test-fixtures/hubdustry-go-mcp/apps/mcp/tools/deploy.go
+++ b/packages/mcp-server/test-fixtures/hubdustry-go-mcp/apps/mcp/tools/deploy.go
@@ -1,0 +1,12 @@
+// FIXTURE: minimal Go for adapter testing — not real code
+// Two mcp.NewTool("server.deploy.{trigger,status}") calls. Combined
+// with files.go the fixture exposes 5 tools total — the adapter must
+// report all 5 as unmappedTools (NAME_MAP is empty for Hubdustry).
+package tools
+
+import "example.com/hubdustry/mcp"
+
+func RegisterDeployTools() {
+	_ = mcp.NewTool("server.deploy.trigger", mcp.WithDescription("Trigger a deploy job"))
+	_ = mcp.NewTool("server.deploy.status", mcp.WithDescription("Read the current deploy status"))
+}

--- a/packages/mcp-server/test-fixtures/hubdustry-go-mcp/apps/mcp/tools/deploy.go
+++ b/packages/mcp-server/test-fixtures/hubdustry-go-mcp/apps/mcp/tools/deploy.go
@@ -1,7 +1,7 @@
 // FIXTURE: minimal Go for adapter testing — not real code
-// Two mcp.NewTool("server.deploy.{trigger,status}") calls. Combined
-// with files.go the fixture exposes 5 tools total — the adapter must
-// report all 5 as unmappedTools (NAME_MAP is empty for Hubdustry).
+// Two NewTool calls (trigger/status). Combined with files.go the
+// fixture exposes 5 tools total — the adapter must report all 5 as
+// unmappedTools (NAME_MAP is empty for Hubdustry).
 package tools
 
 import "example.com/hubdustry/mcp"

--- a/packages/mcp-server/test-fixtures/hubdustry-go-mcp/apps/mcp/tools/files.go
+++ b/packages/mcp-server/test-fixtures/hubdustry-go-mcp/apps/mcp/tools/files.go
@@ -1,0 +1,12 @@
+// FIXTURE: minimal Go for adapter testing — not real code
+// Three mcp.NewTool("server.files.{list,read,write}") calls so the
+// hubdustry-go-mcp adapter's regex picks up exactly three names.
+package tools
+
+import "example.com/hubdustry/mcp"
+
+func RegisterFileTools() {
+	_ = mcp.NewTool("server.files.list", mcp.WithDescription("List files in a server directory"))
+	_ = mcp.NewTool("server.files.read", mcp.WithDescription("Read a file from the server"))
+	_ = mcp.NewTool("server.files.write", mcp.WithDescription("Write a file to the server"))
+}

--- a/packages/mcp-server/test-fixtures/hubdustry-go-mcp/apps/mcp/tools/files.go
+++ b/packages/mcp-server/test-fixtures/hubdustry-go-mcp/apps/mcp/tools/files.go
@@ -1,6 +1,6 @@
 // FIXTURE: minimal Go for adapter testing — not real code
-// Three mcp.NewTool("server.files.{list,read,write}") calls so the
-// hubdustry-go-mcp adapter's regex picks up exactly three names.
+// Three NewTool calls (list/read/write) so the hubdustry-go-mcp
+// adapter's regex picks up exactly three names from this file.
 package tools
 
 import "example.com/hubdustry/mcp"


### PR DESCRIPTION
## Summary

Plan 9 ships the CLI sub-command surface (`doctor`, `init`, `migrate`) on top of the existing stdio server. Backward compat preserved (default `discord-mcp` -> `discord-mcp serve`).

**Status: READY** -- all 6 phases shipped, CI green, `v0.9.0` tag created.

## Phases

- [x] **Phase A** -- Sub-command router + `serve` (backward compat)
- [x] **Phase B** -- `doctor` offline checks (5)
- [x] **Phase C** -- `doctor` online checks (token-online + otel-reachable)
- [x] **Phase D** -- `init` + 4 client snippet generators (claude-desktop, claude-code, cursor, generic)
- [x] **Phase E** -- `migrate` scaffolding + Hubdustry adapter (reference impl)
- [x] **Phase F** -- README + .gitattributes + npm pack smoke + cli binary smoke + tag v0.9.0

## Final stats

- **192 tools** (unchanged from Plan 8)
- **817 tests** passing (621 mcp-core + 196 mcp-server; +3 from Phase F smoke test, +2 skipped when dist/cli.js absent)
- **Zero new runtime deps**
- Tag `v0.9.0` published

## What's new

- `discord-mcp init --client claude-desktop` -- bootstrap MCP client config in 1 command
- `discord-mcp doctor --online` -- diagnose token + OTel reachability
- `discord-mcp migrate --from <adapter>` -- extensible migration framework

## Test plan

- [x] CI green (test 22.12, test 24.x, audit)
- [x] CLI binary smoke test (--version, --help, doctor) passes after pnpm build
- [x] Backward compat: `discord-mcp` (no args) still starts stdio with --gateway support

🤖 Generated with [Claude Code](https://claude.com/claude-code)