### PR TITLE
chore: prepare v0.25.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ writing to Discord.
 
 ## Project status
 
-`discord-mcp` is pre-1.0. This source tree targets **v0.25.0** with 209 tools. Its core exports, CLI surface, environment schema, and tool registry are covered by contract tests; publication is gated on independently verified real-server evidence appropriate to the exact tag commit. See the [GitHub releases](https://github.com/cappyeo/discord-mcp/releases), [changelog](https://cappyeo.github.io/discord-mcp/reference/changelog/), and [v1.0 readiness checklist](https://cappyeo.github.io/discord-mcp/reference/v1-readiness/) before depending on an unstable surface.
+`discord-mcp` is pre-1.0. This source tree targets **v0.25.1** with 209 tools. Its core exports, CLI surface, environment schema, and tool registry are covered by contract tests; publication is gated on trusted exact-tag release checks, protected-main CI, and independently verified real-server evidence appropriate to the exact tag commit. See the [GitHub releases](https://github.com/cappyeo/discord-mcp/releases), [changelog](https://cappyeo.github.io/discord-mcp/reference/changelog/), and [v1.0 readiness checklist](https://cappyeo.github.io/discord-mcp/reference/v1-readiness/) before depending on an unstable surface.
 
 Help validate v1.0: if you have not authored discord-mcp or its documentation,
 follow the [external documentation review](https://cappyeo.github.io/discord-mcp/reference/external-documentation-review/)

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discord-mcp/core",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "private": false,
   "type": "module",
   "description": "Typed caller-owned Discord operations for AI agents, with safety controls, resilience, and verifiable guild builds.",

--- a/packages/mcp-server-mocks/package.json
+++ b/packages/mcp-server-mocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discord-mcp/server-mocks",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discord-mcp/cli",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "private": false,
   "type": "module",
   "mcpName": "io.github.cappyeo/discord-mcp",

--- a/packages/mcp-server/scripts/benchmark/activation-live-adapter.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/activation-live-adapter.test.mjs
@@ -285,7 +285,7 @@ describe('shared activation live adapter', () => {
     const binding = { guildId: GUILD_ID, botId: BOT_ID };
     let registered;
     const session = await adapter.launch({
-      release: '0.25.0',
+      release: '0.25.1',
       hostVersion: '2.1.228',
       target,
       installRoot: 'C:/install',
@@ -353,7 +353,7 @@ describe('shared activation live adapter', () => {
     });
     const target = { guildId: GUILD_ID, botId: BOT_ID };
     const session = await adapter.launch({
-      release: '0.25.0',
+      release: '0.25.1',
       hostVersion: '2.1.228',
       target,
       installRoot: 'C:/install',
@@ -393,7 +393,7 @@ describe('shared activation live adapter', () => {
     });
     const target = { guildId: GUILD_ID, botId: BOT_ID };
     const session = await adapter.launch({
-      release: '0.25.0',
+      release: '0.25.1',
       hostVersion: '2.1.228',
       target,
       installRoot: 'C:/install',
@@ -438,7 +438,7 @@ describe('shared activation live adapter', () => {
     const target = { guildId: GUILD_ID, botId: BOT_ID };
     await expect(
       adapter.launch({
-        release: '0.25.0',
+        release: '0.25.1',
         hostVersion: '2.1.228',
         target,
         installRoot: 'C:/install',
@@ -477,7 +477,7 @@ describe('shared activation live adapter', () => {
     });
     const target = { guildId: GUILD_ID, botId: BOT_ID };
     const session = await adapter.launch({
-      release: '0.25.0',
+      release: '0.25.1',
       hostVersion: '2.1.228',
       target,
       installRoot: 'C:/install',

--- a/packages/mcp-server/scripts/benchmark/activation-trial.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/activation-trial.test.mjs
@@ -7,7 +7,7 @@ import {
 } from './activation-attestation.mjs';
 import { runActivationTrial } from './activation-trial.mjs';
 
-const RELEASE = '0.25.0';
+const RELEASE = '0.25.1';
 const RUN_ID = 'activation-claude-code-20260814';
 const TRIAL_ID = 'claude-code-activation-001';
 const GUILD_ID = '1537332825978568744';

--- a/packages/mcp-server/scripts/benchmark/antigravity-cli-activation-campaign.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/antigravity-cli-activation-campaign.test.mjs
@@ -14,7 +14,7 @@ import {
   runAntigravityCliActivationCampaign,
 } from './antigravity-cli-activation-campaign.mjs';
 
-const RELEASE = '0.25.0';
+const RELEASE = '0.25.1';
 const RUN_ID = 'activation-antigravity-20260815';
 const HOST_VERSION = '1.1.13';
 const GUILD_ID = '1537332825978568744';

--- a/packages/mcp-server/scripts/benchmark/antigravity-cli-activation-live-adapter.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/antigravity-cli-activation-live-adapter.test.mjs
@@ -285,7 +285,7 @@ describe('Antigravity CLI activation live adapter', () => {
     });
     try {
       const session = await adapter.launch({
-        release: '0.25.0',
+        release: '0.25.1',
         hostVersion: '1.1.13',
         target,
         installRoot: root,

--- a/packages/mcp-server/scripts/benchmark/antigravity-cli-activation-trial.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/antigravity-cli-activation-trial.test.mjs
@@ -20,7 +20,7 @@ import {
   validateAntigravityCliActivationRequest,
 } from './antigravity-cli-activation-trial.mjs';
 
-const RELEASE = '0.25.0';
+const RELEASE = '0.25.1';
 const RUN_ID = 'antigravity-cli-activation-run-001';
 const TRIAL_ID = 'antigravity-cli-activation-001';
 const GUILD_ID = '1537332825978568744';

--- a/packages/mcp-server/scripts/benchmark/claude-code-activation-campaign.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/claude-code-activation-campaign.test.mjs
@@ -15,7 +15,7 @@ import {
   runClaudeCodeActivationCampaign,
 } from './claude-code-activation-campaign.mjs';
 
-const RELEASE = '0.25.0';
+const RELEASE = '0.25.1';
 const RUN_ID = 'activation-claude-code-20260815';
 const HOST_VERSION = '1.0.0';
 const GUILD_ID = '1537332825978568744';

--- a/packages/mcp-server/scripts/benchmark/claude-code-activation-live-adapter.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/claude-code-activation-live-adapter.test.mjs
@@ -208,7 +208,7 @@ describe('Claude Code activation live adapter', () => {
     try {
       const binding = fixtureState.target;
       const session = await adapter.launch({
-        release: '0.25.0',
+        release: '0.25.1',
         hostVersion: '2.1.228',
         target: fixtureState.target,
         installRoot: fixtureState.root,
@@ -262,7 +262,7 @@ describe('Claude Code activation live adapter', () => {
     try {
       await expect(
         adapter.launch({
-          release: '0.25.0',
+          release: '0.25.1',
           hostVersion: '2.1.228',
           target: fixtureState.target,
           installRoot: fixtureState.root,

--- a/packages/mcp-server/scripts/benchmark/claude-code-activation-trial.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/claude-code-activation-trial.test.mjs
@@ -18,7 +18,7 @@ import {
 } from './claude-code-activation-trial.mjs';
 import { buildClaudeCodeMcpConfig } from './claude-code-driver.mjs';
 
-const RELEASE = '0.25.0';
+const RELEASE = '0.25.1';
 const RUN_ID = 'claude-code-activation-run-001';
 const TRIAL_ID = 'claude-code-activation-001';
 const GUILD_ID = '1537332825978568744';

--- a/packages/mcp-server/scripts/benchmark/cursor-cli-activation-campaign.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/cursor-cli-activation-campaign.test.mjs
@@ -10,7 +10,7 @@ import {
   runCursorCliActivationCampaign,
 } from './cursor-cli-activation-campaign.mjs';
 
-const RELEASE = '0.25.0';
+const RELEASE = '0.25.1';
 const RUN_ID = 'activation-cursor-20260815';
 const HOST_VERSION = '2.4.1';
 const GUILD_ID = '1537332825978568744';

--- a/packages/mcp-server/scripts/benchmark/cursor-cli-activation-live-adapter.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/cursor-cli-activation-live-adapter.test.mjs
@@ -302,7 +302,7 @@ describe('Cursor Agent CLI activation live adapter', () => {
     });
     try {
       const session = await adapter.launch({
-        release: '0.25.0',
+        release: '0.25.1',
         hostVersion: '2.4.1',
         target,
         installRoot: root,

--- a/packages/mcp-server/scripts/benchmark/cursor-cli-activation-trial.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/cursor-cli-activation-trial.test.mjs
@@ -20,7 +20,7 @@ import {
   validateCursorCliActivationRequest,
 } from './cursor-cli-activation-trial.mjs';
 
-const RELEASE = '0.25.0';
+const RELEASE = '0.25.1';
 const RUN_ID = 'cursor-cli-activation-run-001';
 const TRIAL_ID = 'cursor-cli-activation-001';
 const GUILD_ID = '1537332825978568744';

--- a/packages/mcp-server/scripts/benchmark/grok-cli-activation-campaign.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/grok-cli-activation-campaign.test.mjs
@@ -10,7 +10,7 @@ import {
   runGrokCliActivationCampaign,
 } from './grok-cli-activation-campaign.mjs';
 
-const RELEASE = '0.25.0';
+const RELEASE = '0.25.1';
 const RUN_ID = 'activation-grok-20260815';
 const HOST_VERSION = '1.0.3';
 const GUILD_ID = '1537332825978568744';

--- a/packages/mcp-server/scripts/benchmark/grok-cli-activation-trial.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/grok-cli-activation-trial.test.mjs
@@ -17,7 +17,7 @@ import {
   validateGrokCliActivationRequest,
 } from './grok-cli-activation-trial.mjs';
 
-const RELEASE = '0.25.0';
+const RELEASE = '0.25.1';
 const RUN_ID = 'grok-cli-activation-run-001';
 const TRIAL_ID = 'grok-cli-activation-001';
 const GUILD_ID = '1537332825978568744';
@@ -204,20 +204,20 @@ describe('Grok CLI activation trial guard', () => {
 
   it('binds operator consent to host, release, and trial', () => {
     const value = validateGrokCliActivationRequest({
-      release: '0.25.0',
+      release: '0.25.1',
       runId: 'run-001',
       trialId: 'trial-001',
       hostVersion: '1.2.3',
       sourceCommit: 'a'.repeat(40),
       target,
-      operatorConfirmation: 'APPROVE_GROK_CLI_ACTIVATION:0.25.0:trial-001',
+      operatorConfirmation: 'APPROVE_GROK_CLI_ACTIVATION:0.25.1:trial-001',
       token: 'discord-token',
       executionMode: 'test',
     });
     expect(value.target).toMatchObject(target);
     expect(() =>
       validateGrokCliActivationRequest({
-        release: '0.25.0',
+        release: '0.25.1',
         runId: 'run-001',
         trialId: 'trial-001',
         hostVersion: '1.2.3',
@@ -257,7 +257,7 @@ describe('Grok CLI activation trial guard', () => {
           args: [
             '--yes',
             '--loglevel=error',
-            '@discord-mcp/cli@0.25.0',
+            '@discord-mcp/cli@0.25.1',
             'serve',
             '--profile',
             'devbot',
@@ -270,25 +270,25 @@ describe('Grok CLI activation trial guard', () => {
     };
     expect(
       assertGrokCliConfigReady(config, {
-        release: '0.25.0',
+        release: '0.25.1',
         profile: 'devbot',
         token: 'discord-token',
       }),
     ).toBe(true);
     config.mcp_servers['discord-mcp'].args[2] = '@discord-mcp/cli@0.22.0';
     expect(() =>
-      assertGrokCliConfigReady(config, { release: '0.25.0', profile: 'devbot' }),
+      assertGrokCliConfigReady(config, { release: '0.25.1', profile: 'devbot' }),
     ).toThrow('pinned');
     expect(() =>
       assertGrokCliConfigReady(
         '[permission]\nrules = []\n\n[mcp_servers.discord-mcp]\ncommand = "npx"\n',
-        { release: '0.25.0', profile: 'devbot' },
+        { release: '0.25.1', profile: 'devbot' },
       ),
     ).toThrow('only the generated Grok MCP tables');
     expect(() =>
       assertGrokCliConfigReady(
         'XAI_API_KEY = "persisted"\n\n[mcp_servers.discord-mcp]\ncommand = "npx"\n',
-        { release: '0.25.0', profile: 'devbot' },
+        { release: '0.25.1', profile: 'devbot' },
       ),
     ).toThrow('only the generated Grok MCP tables');
   });

--- a/packages/mcp-server/scripts/benchmark/production-activation-matrix.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/production-activation-matrix.test.mjs
@@ -21,7 +21,7 @@ import {
   PRODUCTION_ACTIVATION_HOSTS,
 } from './verify-activation-trials.mjs';
 
-const RELEASE = '0.25.0';
+const RELEASE = '0.25.1';
 const MATRIX_RUN_ID = 'five-host-live-001';
 const SOURCE_COMMIT = 'a'.repeat(40);
 const GUILD_ID = CONTROLLED_GUILD_IDS[0];

--- a/packages/mcp-server/scripts/benchmark/verify-activation-matrix.test.mjs
+++ b/packages/mcp-server/scripts/benchmark/verify-activation-matrix.test.mjs
@@ -29,7 +29,7 @@ function args(overrides = {}) {
     '--artifact-root',
     ROOT,
     '--expected-release',
-    '0.25.0',
+    '0.25.1',
     '--expected-commit',
     COMMIT,
     '--expected-build-digest',
@@ -74,7 +74,7 @@ describe('production activation matrix CLI', () => {
       schema_version: 'discord-mcp.activation-trials-verifier.v2',
       artifact_schema: 'discord-mcp.activation-trial.v3',
       verified: true,
-      release: '0.25.0',
+      release: '0.25.1',
       source_commit: COMMIT,
       build_digest: BUILD,
       host_count: 5,
@@ -97,7 +97,7 @@ describe('production activation matrix CLI', () => {
     expect(verify.mock.calls[0][0]).toMatchObject({
       integrityKey: TOKEN,
       expectedBinding: { guildId: GUILD_ID, botId: BOT_ID },
-      expectedRelease: '0.25.0',
+      expectedRelease: '0.25.1',
       expectedCommit: COMMIT,
       expectedBuildDigest: BUILD,
     });

--- a/packages/mcp-server/src/commands/doctor.test.ts
+++ b/packages/mcp-server/src/commands/doctor.test.ts
@@ -196,7 +196,7 @@ function createGeminiProfileFixture(tokenReference = '${DISCORD_TOKEN}'): {
             args: [
               '--yes',
               '--loglevel=error',
-              '@discord-mcp/cli@0.25.0',
+              '@discord-mcp/cli@0.25.1',
               'serve',
               '--profile',
               'devbot',
@@ -245,7 +245,7 @@ function createAntigravityProfileFixture(token?: string): {
             args: [
               '--yes',
               '--loglevel=error',
-              '@discord-mcp/cli@0.25.0',
+              '@discord-mcp/cli@0.25.1',
               'serve',
               '--profile',
               'devbot',
@@ -294,7 +294,7 @@ function createCursorCliProfileFixture(credential?: { name: string; value: strin
             args: [
               '--yes',
               '--loglevel=error',
-              '@discord-mcp/cli@0.25.0',
+              '@discord-mcp/cli@0.25.1',
               'serve',
               '--profile',
               'devbot',
@@ -335,7 +335,7 @@ function createGrokCliProfileFixture(credential?: { name: string; value: string 
   );
   writeFileSync(
     configPath,
-    `[mcp_servers.discord-mcp]\ncommand = "npx"\nargs = ["--yes", "--loglevel=error", "@discord-mcp/cli@0.25.0", "serve", "--profile", "devbot"]\nenabled = true\nstartup_timeout_sec = 90\ntool_timeout_sec = 180\n${
+    `[mcp_servers.discord-mcp]\ncommand = "npx"\nargs = ["--yes", "--loglevel=error", "@discord-mcp/cli@0.25.1", "serve", "--profile", "devbot"]\nenabled = true\nstartup_timeout_sec = 90\ntool_timeout_sec = 180\n${
       credential === undefined
         ? ''
         : `\n[mcp_servers.discord-mcp.env]\n${credential.name} = ${JSON.stringify(credential.value)}\n`
@@ -808,7 +808,7 @@ describe('doctorAction - Gemini CLI credential audit', () => {
           profile: 'devbot',
           audited: true,
           server: 'discord-mcp',
-          version: '0.25.0',
+          version: '0.25.1',
           environmentForwarding: true,
           credentialPersisted: false,
         },
@@ -912,7 +912,7 @@ describe('doctorAction - Antigravity CLI credential audit', () => {
           profile: 'devbot',
           audited: true,
           server: 'discord-mcp',
-          version: '0.25.0',
+          version: '0.25.1',
           environmentForwarding: 'inherited',
           credentialPersisted: false,
         },
@@ -985,7 +985,7 @@ describe('doctorAction - Cursor Agent CLI credential audit', () => {
           profile: 'devbot',
           audited: true,
           server: 'discord-mcp',
-          version: '0.25.0',
+          version: '0.25.1',
           environmentForwarding: 'inherited',
           credentialPersisted: false,
         },
@@ -1057,7 +1057,7 @@ describe('doctorAction - Grok CLI credential audit', () => {
       ).toMatchObject({
         status: 'ok',
         details: {
-          version: '0.25.0',
+          version: '0.25.1',
           environmentForwarding: 'inherited',
           credentialPersisted: false,
         },

--- a/packages/mcp-server/src/lib/client-snippets/antigravity-cli-inspector.test.ts
+++ b/packages/mcp-server/src/lib/client-snippets/antigravity-cli-inspector.test.ts
@@ -33,7 +33,7 @@ function writeConfig(profileName = 'devbot', env: Record<string, string> | undef
             args: [
               '--yes',
               '--loglevel=error',
-              '@discord-mcp/cli@0.25.0',
+              '@discord-mcp/cli@0.25.1',
               'serve',
               '--profile',
               profileName,
@@ -65,7 +65,7 @@ describe('inspectAntigravityCliConfig', () => {
 
     expect(inspectAntigravityCliConfig(profile, { config: configPath })).toEqual({
       configName: 'discord-mcp',
-      currentVersion: '0.25.0',
+      currentVersion: '0.25.1',
       environmentForwarding: 'inherited',
       credentialPersisted: false,
     });
@@ -99,7 +99,7 @@ describe('inspectAntigravityCliConfig', () => {
     writeConfig();
 
     expect(inspectAntigravityCliConfig(profile, { homeDirectory: directory }).currentVersion).toBe(
-      '0.25.0',
+      '0.25.1',
     );
   });
 

--- a/packages/mcp-server/src/lib/client-snippets/antigravity-cli.test.ts
+++ b/packages/mcp-server/src/lib/client-snippets/antigravity-cli.test.ts
@@ -6,7 +6,7 @@ const baseConfig = {
   serverArgs: [
     '--yes',
     '--loglevel=error',
-    '@discord-mcp/cli@0.25.0',
+    '@discord-mcp/cli@0.25.1',
     'serve',
     '--profile',
     'devbot',

--- a/packages/mcp-server/src/lib/client-snippets/cursor-cli-inspector.test.ts
+++ b/packages/mcp-server/src/lib/client-snippets/cursor-cli-inspector.test.ts
@@ -30,7 +30,7 @@ function writeConfig(profileName = 'devbot', extra: Record<string, unknown> = {}
             args: [
               '--yes',
               '--loglevel=error',
-              '@discord-mcp/cli@0.25.0',
+              '@discord-mcp/cli@0.25.1',
               'serve',
               '--profile',
               profileName,
@@ -62,7 +62,7 @@ describe('inspectCursorCliConfig', () => {
 
     expect(inspectCursorCliConfig(profile, { config: configPath })).toEqual({
       configName: 'discord-mcp',
-      currentVersion: '0.25.0',
+      currentVersion: '0.25.1',
       environmentForwarding: 'inherited',
       credentialPersisted: false,
     });
@@ -109,7 +109,7 @@ describe('inspectCursorCliConfig', () => {
     writeConfig();
 
     expect(inspectCursorCliConfig(profile, { homeDirectory: directory }).currentVersion).toBe(
-      '0.25.0',
+      '0.25.1',
     );
   });
 

--- a/packages/mcp-server/src/lib/client-snippets/cursor-cli.test.ts
+++ b/packages/mcp-server/src/lib/client-snippets/cursor-cli.test.ts
@@ -7,7 +7,7 @@ const baseConfig = {
   serverArgs: [
     '--yes',
     '--loglevel=error',
-    '@discord-mcp/cli@0.25.0',
+    '@discord-mcp/cli@0.25.1',
     'serve',
     '--profile',
     'devbot',

--- a/packages/mcp-server/src/lib/client-snippets/gemini-cli-inspector.test.ts
+++ b/packages/mcp-server/src/lib/client-snippets/gemini-cli-inspector.test.ts
@@ -31,7 +31,7 @@ function writeConfig(tokenReference = '${DISCORD_TOKEN}', profileName = 'devbot'
             args: [
               '--yes',
               '--loglevel=error',
-              '@discord-mcp/cli@0.25.0',
+              '@discord-mcp/cli@0.25.1',
               'serve',
               '--profile',
               profileName,
@@ -63,7 +63,7 @@ describe('inspectGeminiCliConfig', () => {
 
     expect(inspectGeminiCliConfig(profile, { config: configPath })).toEqual({
       configName: 'discord-mcp',
-      currentVersion: '0.25.0',
+      currentVersion: '0.25.1',
       environmentForwarding: true,
       credentialPersisted: false,
     });
@@ -107,7 +107,7 @@ describe('inspectGeminiCliConfig', () => {
     writeConfig();
 
     expect(inspectGeminiCliConfig(profile, { homeDirectory: directory }).currentVersion).toBe(
-      '0.25.0',
+      '0.25.1',
     );
   });
 
@@ -116,7 +116,7 @@ describe('inspectGeminiCliConfig', () => {
 
     expect(
       inspectGeminiCliConfig(profile, { env: { GEMINI_CLI_HOME: directory } }).currentVersion,
-    ).toBe('0.25.0');
+    ).toBe('0.25.1');
   });
 
   it('rejects oversized settings before parsing them', () => {

--- a/packages/mcp-server/src/lib/client-snippets/grok-cli-inspector.test.ts
+++ b/packages/mcp-server/src/lib/client-snippets/grok-cli-inspector.test.ts
@@ -15,7 +15,7 @@ const profile = {
   gateway: false,
 };
 
-const launcher = `[models]\nmodel = "grok-build"\nenv_key = "XAI_API_KEY"\n\n[mcp_servers.discord-mcp]\ncommand = "npx"\nargs = ["--yes", "--loglevel=error", "@discord-mcp/cli@0.25.0", "serve", "--profile", "devbot"]\nenabled = true\nstartup_timeout_sec = 90\ntool_timeout_sec = 180\n`;
+const launcher = `[models]\nmodel = "grok-build"\nenv_key = "XAI_API_KEY"\n\n[mcp_servers.discord-mcp]\ncommand = "npx"\nargs = ["--yes", "--loglevel=error", "@discord-mcp/cli@0.25.1", "serve", "--profile", "devbot"]\nenabled = true\nstartup_timeout_sec = 90\ntool_timeout_sec = 180\n`;
 const roots: string[] = [];
 
 function fixture(): { path: string; root: string } {
@@ -33,7 +33,7 @@ describe('inspectGrokCliConfig', () => {
     const { path } = fixture();
     writeFileSync(path, launcher);
     expect(inspectGrokCliConfig(profile, { config: path })).toMatchObject({
-      currentVersion: '0.25.0',
+      currentVersion: '0.25.1',
       credentialPersisted: false,
     });
   });
@@ -73,7 +73,7 @@ describe('inspectGrokCliConfig', () => {
     const { root } = fixture();
     writeFileSync(join(root, 'config.toml'), launcher);
     expect(inspectGrokCliConfig(profile, { environment: { GROK_HOME: root } })).toMatchObject({
-      currentVersion: '0.25.0',
+      currentVersion: '0.25.1',
     });
   });
 });

--- a/server.json
+++ b/server.json
@@ -9,17 +9,17 @@
     "id": "1223078565",
     "subfolder": "packages/mcp-server"
   },
-  "version": "0.25.0",
+  "version": "0.25.1",
   "websiteUrl": "https://cappyeo.github.io/discord-mcp/",
   "icons": [
     {
-      "src": "https://raw.githubusercontent.com/cappyeo/discord-mcp/v0.25.0/site/src/assets/discord-mcp-logo-light.png",
+      "src": "https://raw.githubusercontent.com/cappyeo/discord-mcp/v0.25.1/site/src/assets/discord-mcp-logo-light.png",
       "mimeType": "image/png",
       "sizes": ["1024x1024"],
       "theme": "light"
     },
     {
-      "src": "https://raw.githubusercontent.com/cappyeo/discord-mcp/v0.25.0/site/src/assets/discord-mcp-logo-dark.png",
+      "src": "https://raw.githubusercontent.com/cappyeo/discord-mcp/v0.25.1/site/src/assets/discord-mcp-logo-dark.png",
       "mimeType": "image/png",
       "sizes": ["1024x1024"],
       "theme": "dark"
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@discord-mcp/cli",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "transport": {
         "type": "stdio"
       },

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/site/scripts/docs-consistency.test.ts
+++ b/site/scripts/docs-consistency.test.ts
@@ -38,6 +38,11 @@ const CLIENT_SETUP_MDX = join(ROOT, 'site/src/content/docs/start/client-setup.md
 const CONFIGURE_MDX = join(ROOT, 'site/src/content/docs/operations/configure.mdx');
 const SAFETY_REFERENCE_MDX = join(ROOT, 'site/src/content/docs/reference/config/safety.mdx');
 const REFERENCE_INDEX_MDX = join(ROOT, 'site/src/content/docs/reference/index.mdx');
+const ACTIVATION_MATRIX_MDX = join(ROOT, 'site/src/content/docs/reference/activation-matrix.mdx');
+const ACTIVATION_VERIFIER_SOURCE = join(
+  ROOT,
+  'packages/mcp-server/scripts/benchmark/verify-activation-trials.mjs',
+);
 const CLI_REFERENCE_MDX = join(ROOT, 'site/src/content/docs/reference/cli.mdx');
 const HUBDUSTRY_MIGRATION_MDX = join(ROOT, 'site/src/content/docs/migrate/hubdustry.mdx');
 const HUBDUSTRY_FIXTURE_ROOT = join(ROOT, 'packages/mcp-server/test-fixtures/hubdustry-go-mcp');
@@ -423,6 +428,15 @@ describe('handwritten docs do not regress to known stale contracts', () => {
     expect(clientSetup).toContain(`**up to ${tools.length} visible direct tools**`);
     expect(clientSetup).toContain('`MCP_CATEGORIES`');
     expect(clientSetup).toContain('`ALLOWED_GUILDS`');
+  });
+
+  it('keeps the activation matrix schema aligned with the production verifier', () => {
+    const verifier = readFileSync(ACTIVATION_VERIFIER_SOURCE, 'utf8');
+    const schema = verifier.match(/export const ACTIVATION_VERIFIER_SCHEMA = '([^']+)'/)?.[1];
+    expect(schema).toBeDefined();
+
+    const activationMatrix = readFileSync(ACTIVATION_MATRIX_MDX, 'utf8');
+    expect(activationMatrix).toContain(`\`${schema}\``);
   });
 
   it('documents the complete write-control boundary from runtime metadata', async () => {

--- a/site/src/content/docs/reference/activation-matrix.mdx
+++ b/site/src/content/docs/reference/activation-matrix.mdx
@@ -62,11 +62,11 @@ export CURSOR_API_KEY='<Cursor provider key>'
 export XAI_API_KEY='<Grok provider key>'
 
 pnpm benchmark:activation:matrix -- \
-  --release 0.25.0 \
+  --release 0.25.1 \
   --run-id five-host-live-001 \
   --source-commit '<40-character source commit>' \
   --guild '<disposable guild id>' \
-  --confirmation 'APPROVE_FIVE_HOST_ACTIVATION_MATRIX:0.25.0:five-host-live-001:<guild id>:<expected bot id>:<40-character source commit>' \
+  --confirmation 'APPROVE_FIVE_HOST_ACTIVATION_MATRIX:0.25.1:five-host-live-001:<guild id>:<expected bot id>:<40-character source commit>' \
   --codex-version '<installed Codex version>' \
   --claude-code-version '<installed Claude Code version>' \
   --antigravity-cli-version '<installed Antigravity CLI version>' \
@@ -92,7 +92,7 @@ export DISCORD_EXPECTED_BOT_ID='<expected bot id>'
 
 pnpm benchmark:activation:matrix:verify -- \
   --artifact-root /private/discord-mcp-activation \
-  --expected-release 0.25.0 \
+  --expected-release 0.25.1 \
   --expected-commit '<40-character source commit>' \
   --expected-build-digest 'sha256:<64 hex characters>' \
   --codex-run-id codex-activation-live-001 \
@@ -104,7 +104,7 @@ pnpm benchmark:activation:matrix:verify -- \
 
 A successful orchestrated or read-only verification result contains a public
 aggregate that uses
-`discord-mcp.activation-trials-verifier.v1`, reports `verified: true`,
+`discord-mcp.activation-trials-verifier.v2`, reports `verified: true`,
 `host_count: 5`, and contains five three-trial host summaries. Any missing,
 mixed, duplicated, tampered, non-live, unsafe, incomplete, slow, or
 baseline-drifting campaign produces one generic failure envelope and a nonzero

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -11,9 +11,20 @@ commit history and downloadable artifacts, see
 
 ## Unreleased
 
-- Runtime access evidence now keeps Administrator and guild-owner grants
-  complete for declared known permissions even when Discord returns a newer
-  unknown permission bit; the bit remains visible in diagnostics.
+No unreleased changes.
+
+## v0.25.1 - release and runtime hardening
+
+- Corrected runtime access evidence so Administrator and guild-owner grants
+  remain complete for declared known permissions when Discord returns a newer
+  unknown permission bit; the unknown bit remains visible in diagnostics.
+- Upgraded dependencies, security baselines, and the build toolchain,
+  including Astro 7 documentation builds and type checks.
+- Added trusted exact-tag release gates and documented protected-main branch
+  operations; branch protection is an operator control, not package runtime
+  code.
+- Added result-byte budget evidence for representative MCP responses to keep
+  payload growth bounded and measurable.
 
 ## v0.25.0 - verified access and approval hardening
 

--- a/site/src/content/docs/reference/index.mdx
+++ b/site/src/content/docs/reference/index.mdx
@@ -29,7 +29,7 @@ walkthroughs, see [Recipes](/discord-mcp/recipes/).
     { title: 'Environment variables', href: '/discord-mcp/reference/config/', description: 'Exact runtime contract for every supported variable, split into access, safety, runtime, observability, resilience, and audit.' },
     { title: '@discord-mcp/core API', href: '/discord-mcp/reference/api-core/', description: 'Public TypeScript exports for embedding the server in custom transports or extending it with custom tools. defineTool, buildServer, error classes, branded types.' },
     { title: 'AI host activation matrix', href: '/discord-mcp/reference/activation-matrix/', description: 'Independently verify 15 live trials across Codex, Claude Code, Antigravity, Cursor Agent, and Grok Build.' },
-    { title: 'Changelog', href: '/discord-mcp/reference/changelog/', description: 'One section per release v0.0.0 → v0.25.0, with dates and user-visible changes.' },
+    { title: 'Changelog', href: '/discord-mcp/reference/changelog/', description: 'One section per release v0.0.0 → v0.25.1, with dates and user-visible changes.' },
     { title: 'External documentation review', href: '/discord-mcp/reference/external-documentation-review/', description: 'Run the published onboarding journey as a new user and submit credential-safe evidence.' },
     { title: 'v1.0.0 readiness', href: '/discord-mcp/reference/v1-readiness/', description: 'The release gate and stability commitments for the first stable release.' },
   ]}

--- a/site/src/content/docs/reference/v1-readiness.mdx
+++ b/site/src/content/docs/reference/v1-readiness.mdx
@@ -5,17 +5,17 @@ sidebar:
   order: 5
 ---
 
-The current source tree targets discord-mcp v0.25.0 and contains 209 tools.
+The current source tree targets discord-mcp v0.25.1 and contains 209 tools.
 Confirm the latest public version from npm or GitHub Releases. v1.0.0 commits to
 API stability for 6+ months. Tagging v1.0.0 from `main` happens **only** when every
 required box below is ticked. Re-evaluate the evidence before each release;
 unchecked items are real gates, not aspirational release notes.
 
-## Current source evidence (v0.25.0)
+## Current source evidence (v0.25.1)
 
 - The current source tree exposes 209 MCP tools across 31 categories; the
   preceding v0.18.1 packages exposed 203.
-- v0.25.0 adds `discord_intent_plan` as a bounded read-only 209th tool, runtime
+- v0.25.1 carries forward `discord_intent_plan` as a bounded read-only 209th tool, runtime
   access evidence, payload-bound approvals, an optional same-filesystem durable
   approval ledger, and current Discord permission contracts. The tagged
   v0.24.0 release kept the operational 208-tool contract unchanged and added a bounded,
@@ -114,6 +114,10 @@ unchecked items are real gates, not aspirational release notes.
       declared by zero tools, so the documented control restricted nothing)
 - [x] `outputSchema` published for every declaring tool and enforced against
       handler results under test
+- [x] Representative MCP result-byte budgets are measured in contract tests,
+      keeping response growth bounded and reviewable
+- [x] Astro 7 documentation build and `astro check` typecheck pass in the
+      release verification path
 
 ### Distribution
 
@@ -124,6 +128,9 @@ unchecked items are real gates, not aspirational release notes.
       `publishConfig.provenance: true` is actually satisfiable
       (`.github/workflows/release.yml`, behind `workflow_dispatch` + a
       protected environment)
+- [x] Release publication is bound to a trusted exact tag, exact commit, and
+      successful protected-main CI; branch protection itself remains an
+      operator/repository control rather than package code
 - [x] CI fails if the `workspace:` protocol survives into a published
       manifest - npm does not rewrite it, and such a tarball is unrecoverable
       without a deprecate + republish


### PR DESCRIPTION
## Summary

- synchronize package, site, Registry, README, and activation metadata to v0.25.1
- publish the runtime access correction and the verified upgrade/hardening changelog
- refresh current-version fixtures across all five activation hosts
- correct the public activation verifier schema from v1 to v2 and add a source-backed docs drift guard

## Verification

- `RELEASE_TAG=v0.25.1 node .github/scripts/assert-release-metadata.mjs`
- `pnpm lint`
- `pnpm typecheck` (`astro check`: 0 errors, warnings, or hints)
- `pnpm build` (303 docs pages; 304 HTML indexed)
- `pnpm test` (core 1,254 pass; CLI 1,214 pass; site 117 pass; catalog 3 pass)
- focused docs consistency: 24/24 pass
- `pnpm audit`: 0 findings
- `git diff --check`

No tag, package publication, MCP Registry mutation, Discord mutation, or credential change occurs in this PR.