### PR TITLE
ci: bound workflow execution times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -40,6 +41,7 @@ jobs:
       - run: pnpm exec publint --strict packages/mcp-server
   pack:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -54,6 +56,7 @@ jobs:
         run: node .github/scripts/assert-packaged-cli.mjs
   catalog-container:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -67,6 +70,7 @@ jobs:
         run: node .github/scripts/assert-catalog-container.mjs
   audit:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -54,6 +55,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ env:
 jobs:
   preflight:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
@@ -78,6 +79,7 @@ jobs:
     needs: preflight
     if: ${{ !inputs.registry_only }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     environment: npm-publish
     permissions:
       contents: read
@@ -106,6 +108,7 @@ jobs:
     needs: [preflight, publish]
     if: ${{ always() && needs.preflight.result == 'success' && (inputs.registry_only || needs.publish.result == 'success') }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
       id-token: write

--- a/packages/mcp-server/scripts/release-ci-gate.test.mjs
+++ b/packages/mcp-server/scripts/release-ci-gate.test.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { assertReleaseCi } from '../../../.github/scripts/assert-release-ci.mjs';
 import { assertReleaseRef } from '../../../.github/scripts/assert-release-ref.mjs';
@@ -143,5 +143,37 @@ describe('release tag gate', () => {
         gitImpl: (args) => (args.includes('--verify') ? `${sha.slice(0, -1)}8` : sha),
       }),
     ).toThrow('but checkout is');
+  });
+});
+
+describe('workflow timeout policy', () => {
+  it('gives every GitHub Actions job an explicit timeout of at most 20 minutes', () => {
+    const workflowsDirectory = new URL('../../../.github/workflows/', import.meta.url);
+    const workflowNames = readdirSync(workflowsDirectory)
+      .filter((name) => /\.ya?ml$/.test(name))
+      .sort();
+
+    expect(workflowNames.length).toBeGreaterThan(0);
+    for (const workflowName of workflowNames) {
+      const lines = readFileSync(new URL(workflowName, workflowsDirectory), 'utf8').split(/\r?\n/);
+      const jobsIndex = lines.indexOf('jobs:');
+      expect(jobsIndex, `${workflowName} must declare jobs`).toBeGreaterThanOrEqual(0);
+
+      const jobStarts = lines
+        .map((line, index) => ({ index, match: /^ {2}([A-Za-z0-9_-]+):$/.exec(line) }))
+        .filter(({ index, match }) => index > jobsIndex && match !== null);
+
+      expect(jobStarts.length, `${workflowName} must contain at least one job`).toBeGreaterThan(0);
+      for (const [position, job] of jobStarts.entries()) {
+        const end = jobStarts[position + 1]?.index ?? lines.length;
+        const block = lines.slice(job.index, end).join('\n');
+        const timeout = /^ {4}timeout-minutes: (\d+)$/m.exec(block);
+        const jobName = job.match[1];
+
+        expect(timeout, `${workflowName}:${jobName} must declare timeout-minutes`).not.toBeNull();
+        expect(Number(timeout?.[1]), `${workflowName}:${jobName} timeout`).toBeGreaterThan(0);
+        expect(Number(timeout?.[1]), `${workflowName}:${jobName} timeout`).toBeLessThanOrEqual(20);
+      }
+    }
   });
 });


### PR DESCRIPTION
Adds explicit 10- or 20-minute job timeouts across CI, docs, release, and external-link workflows, plus a regression test that scans every YAML workflow and rejects missing, zero, or over-20-minute job bounds. Verification: full CLI suite 1215 passed / 9 skipped / 1 todo; targeted policy suite 8 passed; lint clean across 967 files; diff check clean. Independent review found no blocking issues.