### PR TITLE
fix: harden CodeQL credential and parser findings

### DIFF
--- a/.github/scripts/assert-release-ci.mjs
+++ b/.github/scripts/assert-release-ci.mjs
@@ -1,6 +1,21 @@
 import { pathToFileURL } from 'node:url';
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+const OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$/;
+const REPOSITORY_PATTERN = /^(?!\.{1,2}$)[A-Za-z0-9._-]{1,100}$/;
+
+function parseRepository(value) {
+  if (typeof value !== 'string') throw new Error('GITHUB_REPOSITORY is required');
+  const parts = value.split('/');
+  if (
+    parts.length !== 2 ||
+    !OWNER_PATTERN.test(parts[0] ?? '') ||
+    !REPOSITORY_PATTERN.test(parts[1] ?? '')
+  ) {
+    throw new Error('GITHUB_REPOSITORY must use the exact owner/repository form');
+  }
+  return parts;
+}
 
 export async function assertReleaseCi({
   sha,
@@ -12,12 +27,17 @@ export async function assertReleaseCi({
   if (!SHA_PATTERN.test(sha ?? '')) {
     throw new Error(`RELEASE_SHA must be a 40-character commit SHA, received ${sha ?? '(unset)'}`);
   }
-  if (!repository) throw new Error('GITHUB_REPOSITORY is required');
+  const [owner, name] = parseRepository(repository);
   if (!token) throw new Error('GITHUB_TOKEN is required');
   if (typeof fetchImpl !== 'function') throw new Error('fetch is unavailable');
 
-  const url = `https://api.github.com/repos/${repository}/actions/runs?head_sha=${sha}&per_page=100`;
+  const url = new URL(
+    `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/actions/runs`,
+  );
+  url.searchParams.set('head_sha', sha);
+  url.searchParams.set('per_page', '100');
   const response = await fetchImpl(url, {
+    redirect: 'error',
     headers: {
       accept: 'application/vnd.github+json',
       authorization: `Bearer ${token}`,

--- a/packages/mcp-core/src/pipeline/interpolate.test.ts
+++ b/packages/mcp-core/src/pipeline/interpolate.test.ts
@@ -35,6 +35,7 @@ describe('interpolate', () => {
   const vars = {
     step1: { id: 'msg_123', count: 5 },
     step2: { url: 'https://example.com' },
+    'step{3': { id: 'brace-compatible' },
   };
 
   it('returns raw value (type-preserved) when entire string is a single template', () => {
@@ -53,6 +54,11 @@ describe('interpolate', () => {
     expect(interpolate('hello {{absent.var}}', vars)).toBe('hello {{absent.var}}');
   });
 
+  it('preserves the existing support for opening braces inside a path', () => {
+    expect(interpolate('{{step{3.id}}', vars)).toBe('brace-compatible');
+    expect(interpolate('value={{step{3.id}}', vars)).toBe('value=brace-compatible');
+  });
+
   it('returns undefined when a single-template references a missing path', () => {
     expect(interpolate('{{absent.var}}', vars)).toBeUndefined();
   });
@@ -69,6 +75,11 @@ describe('interpolate', () => {
 
   it('does not interpolate non-string primitives', () => {
     expect(interpolate({ n: 42, b: true, nul: null }, vars)).toEqual({ n: 42, b: true, nul: null });
+  });
+
+  it('handles a long unterminated template prefix without regex backtracking', () => {
+    const hostile = '{{'.repeat(20_000);
+    expect(interpolate(hostile, vars)).toBe(hostile);
   });
 });
 

--- a/packages/mcp-core/src/pipeline/interpolate.ts
+++ b/packages/mcp-core/src/pipeline/interpolate.ts
@@ -1,5 +1,41 @@
-const TEMPLATE_RE = /\{\{([^}]+)\}\}/g;
-const SINGLE_TEMPLATE_RE = /^\{\{([^}]+)\}\}$/;
+function singleTemplatePath(value: string): string | undefined {
+  if (!value.startsWith('{{') || !value.endsWith('}}')) return undefined;
+  const path = value.slice(2, -2);
+  return path.length > 0 && !path.includes('}') ? path : undefined;
+}
+
+function interpolateString(value: string, vars: Record<string, unknown>): string {
+  const pieces: string[] = [];
+  let candidate = -1;
+  let emitted = 0;
+  let scan = 0;
+
+  while (scan < value.length - 1) {
+    if (value[scan] === '{' && value[scan + 1] === '{') {
+      if (candidate === -1) candidate = scan;
+      scan += 2;
+      continue;
+    }
+    if (value[scan] === '}' && value[scan + 1] === '}') {
+      if (candidate !== -1 && scan > candidate + 2) {
+        const full = value.slice(candidate, scan + 2);
+        const path = value.slice(candidate + 2, scan).trim();
+        const resolved = resolvePath(path, vars);
+        pieces.push(value.slice(emitted, candidate));
+        pieces.push(resolved === undefined ? full : String(resolved));
+        emitted = scan + 2;
+      }
+      candidate = -1;
+      scan += 2;
+      continue;
+    }
+    if (value[scan] === '}') candidate = -1;
+    scan += 1;
+  }
+
+  pieces.push(value.slice(emitted));
+  return pieces.join('');
+}
 
 export function resolvePath(path: string, vars: Record<string, unknown>): unknown {
   const segments = path
@@ -18,15 +54,12 @@ export function resolvePath(path: string, vars: Record<string, unknown>): unknow
 
 export function interpolate<T>(value: T, vars: Record<string, unknown>): T {
   if (typeof value === 'string') {
-    const single = value.match(SINGLE_TEMPLATE_RE);
-    if (single !== null) {
-      const path = single[1]!.trim();
+    const single = singleTemplatePath(value);
+    if (single !== undefined) {
+      const path = single.trim();
       return resolvePath(path, vars) as never as T;
     }
-    return value.replace(TEMPLATE_RE, (full, path: string) => {
-      const resolved = resolvePath(path.trim(), vars);
-      return resolved === undefined ? full : String(resolved);
-    }) as never as T;
+    return interpolateString(value, vars) as never as T;
   }
   if (Array.isArray(value)) {
     return value.map((v) => interpolate(v, vars)) as never as T;
@@ -43,8 +76,8 @@ export function interpolate<T>(value: T, vars: Record<string, unknown>): T {
 
 export function evalCondition(expr: string, vars: Record<string, unknown>): boolean {
   const trimmed = expr.trim();
-  const single = trimmed.match(SINGLE_TEMPLATE_RE);
-  const path = single !== null ? single[1]!.trim() : trimmed;
+  const single = singleTemplatePath(trimmed);
+  const path = single !== undefined ? single.trim() : trimmed;
   const value = resolvePath(path, vars);
   return Boolean(value);
 }

--- a/packages/mcp-core/src/tools/_lib/untrusted.test.ts
+++ b/packages/mcp-core/src/tools/_lib/untrusted.test.ts
@@ -51,6 +51,12 @@ describe('wrapUntrusted', () => {
     expect(u).toContain('<untrusted_discord_username');
     expect(t).toContain('<untrusted_discord_template');
   });
+
+  it('handles a long unterminated hostile fence without regex backtracking', () => {
+    const hostile = `<untrusted_discord_${'_'.repeat(100_000)}`;
+    const wrapped = wrapUntrusted(hostile, 'message');
+    expect(wrapped).toContain(hostile);
+  });
 });
 
 describe('wrapMessages', () => {

--- a/packages/mcp-core/src/tools/_lib/untrusted.ts
+++ b/packages/mcp-core/src/tools/_lib/untrusted.ts
@@ -21,15 +21,34 @@ function escapeAttr(s: string): string {
     .replace(/>/g, '&gt;');
 }
 
-function stripTags(content: string, tagPattern: RegExp): string {
-  return content.replace(tagPattern, '[FILTERED_TAG]');
+function stripPrefixedTags(content: string, prefix: string): string {
+  const lower = content.toLowerCase();
+  const pieces: string[] = [];
+  let cursor = 0;
+  while (cursor < content.length) {
+    const start = content.indexOf('<', cursor);
+    if (start === -1) break;
+    const nameStart = lower[start + 1] === '/' ? start + 2 : start + 1;
+    if (!lower.startsWith(prefix, nameStart)) {
+      pieces.push(content.slice(cursor, start + 1));
+      cursor = start + 1;
+      continue;
+    }
+    const end = content.indexOf('>', nameStart + prefix.length);
+    if (end === -1) break;
+    pieces.push(content.slice(cursor, start), '[FILTERED_TAG]');
+    cursor = end + 1;
+  }
+  pieces.push(content.slice(cursor));
+  return pieces.join('');
 }
 
-const outerRe = /<\/?untrusted_discord_[a-z_]*[^>]*>/gi;
+const OUTER_TAG_PREFIX = 'untrusted_discord_';
+const MESSAGE_TAG_PREFIX = 'msg';
 
 export function wrapUntrusted(content: string, kind: UntrustedKind): string {
   const tag = `untrusted_discord_${kind}`;
-  const safe = stripTags(content, outerRe);
+  const safe = stripPrefixedTags(content, OUTER_TAG_PREFIX);
   const n = nonce();
   return [
     `<${tag} nonce="${n}">`,
@@ -47,12 +66,11 @@ export interface MessageForWrap {
 
 export function wrapMessages(messages: readonly MessageForWrap[], channelId: string): string {
   const n = nonce();
-  const msgTagRe = /<\/?msg[^>]*>/gi;
   const inner = messages
     .map(
       (m) =>
         `<msg id="${escapeAttr(m.id)}" author="${escapeAttr(m.author)}">` +
-        `${stripTags(stripTags(m.content, msgTagRe), outerRe)}` +
+        `${stripPrefixedTags(stripPrefixedTags(m.content, MESSAGE_TAG_PREFIX), OUTER_TAG_PREFIX)}` +
         `</msg>`,
     )
     .join('\n');

--- a/packages/mcp-server/scripts/release-ci-gate.test.mjs
+++ b/packages/mcp-server/scripts/release-ci-gate.test.mjs
@@ -98,6 +98,21 @@ describe('release CI gate', () => {
     ).rejects.toThrow('no successful CI run');
   });
 
+  it.each([
+    'https://attacker.example/repo',
+    'owner/repo?per_page=1',
+    'owner/repo#fragment',
+    'owner/../other',
+    'owner/.',
+  ])('rejects an unsafe repository identifier before fetching: %s', async (repository) => {
+    const fetchImpl = () => {
+      throw new Error('fetch must not run');
+    };
+    await expect(
+      assertReleaseCi({ sha, repository, token: 'test-token', fetchImpl }),
+    ).rejects.toThrow('exact owner/repository form');
+  });
+
   it('wires npm publish and registry-only retries through trusted-main preflight', () => {
     const workflow = readFileSync(
       new URL('../../../.github/workflows/release.yml', import.meta.url),

--- a/packages/mcp-server/src/commands/doctor.integration.test.ts
+++ b/packages/mcp-server/src/commands/doctor.integration.test.ts
@@ -15,11 +15,9 @@
  *   - GET /api/v10/users/@me  → mocks Discord (token-online)
  *   - HEAD /v1/traces         → mocks OTLP collector (otel-reachable)
  *
- * Test-only env overrides used here:
- *   - DISCORD_API_BASE_URL → swaps the Discord base URL inside
- *     token-online.ts so we hit the loopback server. Documented in that
- *     file's header as test-only.
- *   - OTEL_EXPORTER_OTLP_ENDPOINT → standard config knob; we just point
+ * Test-only seams used here:
+ *   - global fetch redirects only the fixed Discord origin to loopback.
+ *   - OTEL_EXPORTER_OTLP_ENDPOINT → standard config knob; we point
  *     it at the loopback server (this is its real production knob).
  *
  * The test asserts all 7 checks appear in the JSON output with their
@@ -35,11 +33,11 @@ let baseUrl: string;
 
 const VALID_TOKEN = `Bot ${'a'.repeat(60)}`;
 
-const originalDiscordApiBase = process.env.DISCORD_API_BASE_URL;
 const originalToken = process.env.DISCORD_TOKEN;
 const originalOtelEnabled = process.env.OTEL_ENABLED;
 const originalOtelEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
 const originalExitCode = process.exitCode;
+const realFetch = globalThis.fetch;
 
 let stdoutWrites: string[] = [];
 
@@ -80,8 +78,7 @@ beforeEach(() => {
     stdoutWrites.push(typeof chunk === 'string' ? chunk : String(chunk));
     return true;
   });
-  // Point Discord at our loopback server.
-  process.env.DISCORD_API_BASE_URL = `${baseUrl}/api/v10`;
+  vi.stubGlobal('fetch', discordLoopbackFetch(baseUrl));
   process.env.DISCORD_TOKEN = VALID_TOKEN;
   process.env.OTEL_ENABLED = 'true';
   process.env.OTEL_EXPORTER_OTLP_ENDPOINT = baseUrl;
@@ -90,11 +87,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
-  if (originalDiscordApiBase !== undefined) {
-    process.env.DISCORD_API_BASE_URL = originalDiscordApiBase;
-  } else {
-    delete process.env.DISCORD_API_BASE_URL;
-  }
+  vi.unstubAllGlobals();
   if (originalToken !== undefined) {
     process.env.DISCORD_TOKEN = originalToken;
   } else {
@@ -115,6 +108,17 @@ afterEach(() => {
 
 function stdoutOutput(): string {
   return stdoutWrites.join('');
+}
+
+function discordLoopbackFetch(loopbackOrigin: string): typeof fetch {
+  return (async (input, init) => {
+    const raw = input instanceof Request ? input.url : input instanceof URL ? input.href : input;
+    const url = new URL(raw);
+    if (url.origin === 'https://discord.com' && url.pathname.startsWith('/api/v10/')) {
+      return realFetch(new URL(`${url.pathname}${url.search}`, loopbackOrigin), init);
+    }
+    return realFetch(input, init);
+  }) as typeof fetch;
 }
 
 /**
@@ -144,10 +148,6 @@ async function runDoctorAndCapture(
 
 describe('doctorAction online integration (Plan 9 Phase C)', () => {
   it('runs all 7 checks against a live loopback server and reports JSON', async () => {
-    // NOTE: token-online.ts caches DISCORD_API_BASE at module-eval time. We
-    // import doctor here AFTER setting DISCORD_API_BASE_URL so the cached
-    // value picks up the loopback URL. vi.resetModules() ensures a fresh
-    // import even if a previous test already evaluated the module.
     vi.resetModules();
     const { doctorAction } = await import('./doctor.js');
 
@@ -194,7 +194,7 @@ describe('doctorAction online integration (Plan 9 Phase C)', () => {
     // response by toggling a flag the handler checks.
     //
     // Simpler approach: spin up a SECOND server for this test that always
-    // returns 401, point DISCORD_API_BASE_URL there, run doctor.
+    // returns 401 and redirect only the fixed Discord fetch to it.
     const failingServer = createServer((req, res) => {
       if (req.method === 'GET' && req.url === '/api/v10/users/@me') {
         res.writeHead(401);
@@ -214,8 +214,8 @@ describe('doctorAction online integration (Plan 9 Phase C)', () => {
     const failingUrl = `http://127.0.0.1:${failingAddr.port}`;
 
     try {
-      process.env.DISCORD_API_BASE_URL = `${failingUrl}/api/v10`;
       process.env.OTEL_EXPORTER_OTLP_ENDPOINT = failingUrl;
+      vi.stubGlobal('fetch', discordLoopbackFetch(failingUrl));
 
       vi.resetModules();
       const { doctorAction } = await import('./doctor.js');

--- a/packages/mcp-server/src/commands/doctor.test.ts
+++ b/packages/mcp-server/src/commands/doctor.test.ts
@@ -346,8 +346,7 @@ function createGrokCliProfileFixture(credential?: { name: string; value: string 
 
 function onlineDoctorFetch(latestVersion: string | undefined): ReturnType<typeof vi.fn> {
   return vi.fn(async (input: string | URL | Request): Promise<Response> => {
-    const url = String(input);
-    if (url.includes('registry.npmjs.org')) {
+    if (isNpmRegistryRequest(input)) {
       return latestVersion === undefined
         ? new Response('', { status: 503 })
         : new Response(JSON.stringify({ 'dist-tags': { latest: latestVersion } }), {
@@ -361,6 +360,28 @@ function onlineDoctorFetch(latestVersion: string | undefined): ReturnType<typeof
     });
   });
 }
+
+function isNpmRegistryRequest(input: string | URL | Request): boolean {
+  const raw = input instanceof Request ? input.url : input instanceof URL ? input.href : input;
+  try {
+    const url = new URL(raw);
+    return (
+      url.protocol === 'https:' &&
+      url.hostname === 'registry.npmjs.org' &&
+      url.pathname === '/@discord-mcp%2fcli'
+    );
+  } catch {
+    return false;
+  }
+}
+
+describe('npm registry request boundary', () => {
+  it('matches only the exact HTTPS npm registry endpoint', () => {
+    expect(isNpmRegistryRequest('https://registry.npmjs.org/@discord-mcp%2fcli')).toBe(true);
+    expect(isNpmRegistryRequest('https://attacker.example/?next=registry.npmjs.org')).toBe(false);
+    expect(isNpmRegistryRequest('http://registry.npmjs.org/@discord-mcp%2fcli')).toBe(false);
+  });
+});
 
 describe('doctor profile activation', () => {
   it('reports a missing profile without running the check suite', async () => {
@@ -741,9 +762,7 @@ describe('doctorAction - Codex launcher update discovery', () => {
       const updateCheck = parsed.data.checks.find((check) => check.id === 'codex-launcher-update');
       expect(parsed.exitCode).toBe(0);
       expect(updateCheck).toMatchObject({ status: 'ok', details: { managed: false } });
-      expect(
-        fetchMock.mock.calls.some(([input]) => String(input).includes('registry.npmjs.org')),
-      ).toBe(false);
+      expect(fetchMock.mock.calls.some(([input]) => isNpmRegistryRequest(input))).toBe(false);
     } finally {
       rmSync(fixture.directory, { recursive: true, force: true });
     }

--- a/packages/mcp-server/src/commands/init.test.ts
+++ b/packages/mcp-server/src/commands/init.test.ts
@@ -33,6 +33,7 @@ const originalStdinTTY = process.stdin.isTTY;
 const originalStdoutTTY = process.stdout.isTTY;
 const originalExitCode = process.exitCode;
 const originalDiscordToken = process.env.DISCORD_TOKEN;
+const originalDiscordApiBaseUrl = process.env.DISCORD_API_BASE_URL;
 
 let stdoutWrites: string[] = [];
 
@@ -66,6 +67,8 @@ afterEach(() => {
   } else {
     process.env.DISCORD_TOKEN = originalDiscordToken;
   }
+  if (originalDiscordApiBaseUrl === undefined) delete process.env.DISCORD_API_BASE_URL;
+  else process.env.DISCORD_API_BASE_URL = originalDiscordApiBaseUrl;
   Object.defineProperty(process.stdin, 'isTTY', {
     value: originalStdinTTY,
     configurable: true,
@@ -365,6 +368,7 @@ describe('initAction - live guild discovery', () => {
 
   it('uses DISCORD_TOKEN to verify a sole guild without persisting the secret', async () => {
     process.env.DISCORD_TOKEN = VALID_TOKEN;
+    process.env.DISCORD_API_BASE_URL = 'https://attacker.example/api/v10';
     const guildId = '111122223333444455';
     const fetchMock = stubDiscord([{ id: guildId, name: 'Test Guild', permissions: '0' }]);
 
@@ -384,7 +388,13 @@ describe('initAction - live guild discovery', () => {
     expect(parsed.data?.content).not.toContain('x'.repeat(60));
     expect(parsed.data?.discord?.bot).toEqual({ id: BOT.id, username: BOT.username });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(
+      fetchMock.mock.calls.every(([input]) =>
+        String(input).startsWith('https://discord.com/api/v10/'),
+      ),
+    ).toBe(true);
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      redirect: 'error',
       headers: expect.objectContaining({ Authorization: VALID_TOKEN }),
     });
   });

--- a/packages/mcp-server/src/commands/init.ts
+++ b/packages/mcp-server/src/commands/init.ts
@@ -100,9 +100,9 @@ function discordAuthHeader(token: string): string {
 }
 
 async function discordGet(path: string, token: string): Promise<unknown> {
-  const baseUrl = process.env.DISCORD_API_BASE_URL ?? DISCORD_API_DEFAULT;
-  const response = await fetch(`${baseUrl}${path}`, {
+  const response = await fetch(`${DISCORD_API_DEFAULT}${path}`, {
     method: 'GET',
+    redirect: 'error',
     headers: {
       Authorization: discordAuthHeader(token),
       'User-Agent': 'discord-mcp-init (https://github.com/cappyeo/discord-mcp)',

--- a/packages/mcp-server/src/commands/update.test.ts
+++ b/packages/mcp-server/src/commands/update.test.ts
@@ -40,16 +40,15 @@ function createProfile(client: 'codex' | 'generic' = 'codex', name = 'devbot'): 
   );
 }
 
-function registry(version = NEXT): void {
-  vi.stubGlobal(
-    'fetch',
-    vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ 'dist-tags': { latest: version } }), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      }),
-    ),
+function registry(version = NEXT): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ 'dist-tags': { latest: version } }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }),
   );
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
 }
 
 function output(): Record<string, unknown> {
@@ -79,7 +78,7 @@ describe('updateAction', () => {
   it('reports an available update without changing the launcher', async () => {
     createProfile();
     writeFileSync(configPath, generatedLauncher());
-    registry();
+    const fetchMock = registry();
 
     await updateAction({ profile: 'devbot', config: configPath, profileDirectory, json: true });
 
@@ -95,6 +94,10 @@ describe('updateAction', () => {
       },
     });
     expect(readFileSync(configPath, 'utf8')).toBe(generatedLauncher());
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://registry.npmjs.org/@discord-mcp%2fcli',
+      expect.objectContaining({ redirect: 'error' }),
+    );
   });
 
   it('updates only the exact generated launcher after --apply', async () => {

--- a/packages/mcp-server/src/commands/update.ts
+++ b/packages/mcp-server/src/commands/update.ts
@@ -20,7 +20,6 @@ export interface UpdateOptions {
   profileDirectory?: string;
   homeDirectory?: string;
   env?: NodeJS.ProcessEnv;
-  registryUrl?: string;
 }
 
 interface VersionParts {
@@ -133,11 +132,12 @@ function resolveCodexConfigPath(
   return join(root, 'config.toml');
 }
 
-async function latestPublishedVersion(registryUrl = REGISTRY_URL): Promise<string> {
+async function latestPublishedVersion(): Promise<string> {
   let response: Response;
   try {
-    response = await fetch(registryUrl, {
+    response = await fetch(REGISTRY_URL, {
       headers: { accept: 'application/json' },
+      redirect: 'error',
       signal: AbortSignal.timeout(5_000),
     });
   } catch (error) {
@@ -435,13 +435,13 @@ function writeAtomically(path: string, content: string): void {
 
 export async function inspectCodexLauncherUpdate(
   profile: DiscordMcpProfile,
-  options: Pick<UpdateOptions, 'config' | 'homeDirectory' | 'env' | 'registryUrl'> = {},
+  options: Pick<UpdateOptions, 'config' | 'homeDirectory' | 'env'> = {},
 ): Promise<CodexLauncherUpdateInspection> {
   const source = readGeneratedCodexLauncher(profile, options);
 
   let targetVersion: string;
   try {
-    targetVersion = await latestPublishedVersion(options.registryUrl);
+    targetVersion = await latestPublishedVersion();
   } catch (error) {
     throw new CodexLauncherUpdateError(
       'registry-unavailable',

--- a/packages/mcp-server/src/lib/checks/bot-access.test.ts
+++ b/packages/mcp-server/src/lib/checks/bot-access.test.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from '@discord-mcp/core';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { botAccessPreflightCheck } from './bot-access.js';
 
 const GUILD_ID = '111122223333444455';
@@ -29,6 +29,7 @@ function fetcherFor(
   authorizationHeaders: string[] = [],
 ): typeof fetch {
   return (async (input, init) => {
+    expect(init?.redirect).toBe('error');
     const url = String(input);
     const path = new URL(url).pathname;
     calls.push(path);
@@ -43,7 +44,6 @@ function fetcherFor(
 
 describe('botAccessPreflightCheck', () => {
   it('returns identity, permission, intent, and tool evidence for one guild', async () => {
-    process.env.DISCORD_API_BASE_URL = 'https://doctor.test/api/v10';
     const calls: string[] = [];
     const authorizationHeaders: string[] = [];
     const result = await botAccessPreflightCheck({
@@ -144,7 +144,6 @@ describe('botAccessPreflightCheck', () => {
   });
 
   it('reports consent-required DM execution separately from identity readiness', async () => {
-    process.env.DISCORD_API_BASE_URL = 'https://doctor.test/api/v10';
     const result = await botAccessPreflightCheck({
       config: loadConfig({
         DISCORD_TOKEN: TOKEN,
@@ -201,6 +200,23 @@ describe('botAccessPreflightCheck', () => {
     expect(result.status).toBe('fail');
     expect(result.message).toContain('identity mismatch');
     expect(JSON.stringify(result)).not.toContain(TOKEN);
+  });
+
+  it('ignores a remote API override and sends the bot credential only to Discord', async () => {
+    process.env.DISCORD_API_BASE_URL = 'https://attacker.example/api/v10';
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      expect(new URL(String(input)).origin).toBe('https://discord.com');
+      expect(new Headers(init?.headers).get('authorization')).toBe(TOKEN);
+      return new Response('', { status: 401 });
+    });
+
+    const result = await botAccessPreflightCheck({
+      config: config(),
+      fetcher: fetcher as typeof fetch,
+    });
+
+    expect(result).toMatchObject({ id: 'bot-access', status: 'fail' });
+    expect(fetcher).toHaveBeenCalledOnce();
   });
 
   it('fails closed when the application points at a different bot', async () => {

--- a/packages/mcp-server/src/lib/checks/bot-access.ts
+++ b/packages/mcp-server/src/lib/checks/bot-access.ts
@@ -10,6 +10,7 @@ import type { CheckResult } from './index.js';
 const SNOWFLAKE_RE = /^\d{17,20}$/;
 const PERMISSION_RE = /^\d+$/;
 const REQUEST_TIMEOUT_MS = 8_000;
+const DISCORD_API_BASE_URL = 'https://discord.com/api/v10';
 const INTENT_FLAGS: Readonly<
   Record<GatewayIntentName, { readonly approved: bigint; readonly limited: bigint }>
 > = {
@@ -91,13 +92,6 @@ function permissionString(value: unknown, label: string): string {
   return value;
 }
 
-function baseUrl(): string {
-  const configured = process.env.DISCORD_API_BASE_URL?.trim();
-  const raw =
-    configured === undefined || configured === '' ? 'https://discord.com/api/v10' : configured;
-  return raw.replace(/\/$/u, '');
-}
-
 function authHeader(token: string): string {
   return `Bot ${token.startsWith('Bot ') ? token.slice(4) : token}`;
 }
@@ -119,6 +113,7 @@ async function fetchJson(
 ): Promise<JsonResponse> {
   const response = await fetcher(`${base}${path}`, {
     method: 'GET',
+    redirect: 'error',
     headers: {
       Authorization: authHeader(token),
       'User-Agent': 'discord-mcp-doctor (https://github.com/cappyeo/discord-mcp)',
@@ -622,7 +617,7 @@ export async function botAccessPreflightCheck(options: BotAccessOptions): Promis
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
   const warnings: string[] = [];
-  const base = baseUrl();
+  const base = DISCORD_API_BASE_URL;
   let user: RawUser;
   let application: RawApplication | null = null;
 

--- a/packages/mcp-server/src/lib/checks/token-online.test.ts
+++ b/packages/mcp-server/src/lib/checks/token-online.test.ts
@@ -17,13 +17,17 @@ function makeConfig(token: string, expectedBotId?: string): Config {
 }
 
 const VALID_TOKEN = `Bot ${'a'.repeat(60)}`;
+const originalDiscordApiBaseUrl = process.env.DISCORD_API_BASE_URL;
 
 beforeEach(() => {
   vi.unstubAllGlobals();
+  delete process.env.DISCORD_API_BASE_URL;
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  if (originalDiscordApiBaseUrl === undefined) delete process.env.DISCORD_API_BASE_URL;
+  else process.env.DISCORD_API_BASE_URL = originalDiscordApiBaseUrl;
 });
 
 describe('tokenOnlineCheck', () => {
@@ -57,6 +61,23 @@ describe('tokenOnlineCheck', () => {
     expect(r.details).toEqual({ username: 'bot-name', id: '1234', bot: true });
   });
 
+  it('ignores a remote API override and sends the bot credential only to Discord', async () => {
+    process.env.DISCORD_API_BASE_URL = 'https://attacker.example/api/v10';
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await tokenOnlineCheck.run(makeConfig(VALID_TOKEN));
+
+    expect(result).toMatchObject({ status: 'fail' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://discord.com/api/v10/users/@me',
+      expect.objectContaining({
+        redirect: 'error',
+        headers: expect.objectContaining({ Authorization: VALID_TOKEN }),
+      }),
+    );
+  });
+
   it('uses Authorization: Bot <token> with leading "Bot " stripped+re-added', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ id: '1', username: 'x', bot: false }), {
@@ -70,6 +91,7 @@ describe('tokenOnlineCheck', () => {
     // exactly one "Bot " prefix in the Authorization header.
     await tokenOnlineCheck.run(makeConfig(`Bot ${'x'.repeat(60)}`));
     const headers = (fetchMock.mock.calls[0]?.[1] as { headers: Record<string, string> }).headers;
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ redirect: 'error' });
     const auth = headers.Authorization ?? '';
     expect(auth).toBe(`Bot ${'x'.repeat(60)}`);
     expect(auth.startsWith('Bot Bot ')).toBe(false);

--- a/packages/mcp-server/src/lib/checks/token-online.ts
+++ b/packages/mcp-server/src/lib/checks/token-online.ts
@@ -10,19 +10,17 @@
  * surface the resolved bot identity (username, id, bot flag) on success
  * and HTTP status / error message on failure.
  *
- * Test-only escape hatch: `DISCORD_API_BASE_URL` env override. Defaults
- * to `https://discord.com/api/v10`. Integration tests set this to a
- * loopback `node:http` server (see doctor.integration.test.ts). NEVER
- * documented in user-facing help - it exists purely to avoid pulling in
- * `nock` / `msw` for ONLINE network tests.
+ * The request target is fixed to Discord. Integration tests redirect fetch at
+ * the test boundary rather than exposing a production URL override.
  *
  * Timeout: 5 seconds via AbortController. On abort we report 'warn'
  * (treating the result as inconclusive rather than failed) so transient
  * network issues don't block the user from running their MCP server.
  */
+
 import type { DoctorCheck } from './index.js';
 
-const DISCORD_API_BASE = process.env.DISCORD_API_BASE_URL ?? 'https://discord.com/api/v10';
+const DISCORD_API_BASE_URL = 'https://discord.com/api/v10';
 const REQUEST_TIMEOUT_MS = 5000;
 
 /**
@@ -54,13 +52,14 @@ export const tokenOnlineCheck: DoctorCheck = {
       };
     }
 
-    const url = `${DISCORD_API_BASE}/users/@me`;
+    const url = `${DISCORD_API_BASE_URL}/users/@me`;
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
 
     try {
       const res = await fetch(url, {
         method: 'GET',
+        redirect: 'error',
         headers: {
           Authorization: authHeader(config.DISCORD_TOKEN),
           'User-Agent': 'discord-mcp-doctor (https://github.com/cappyeo/discord-mcp)',

--- a/packages/mcp-server/src/otel.ts
+++ b/packages/mcp-server/src/otel.ts
@@ -223,10 +223,9 @@ export function isOtlpSelfTrace(url: string): boolean {
  * so the hook silently did nothing in production while its test passed by
  * handing it an origin undici never produces.
  *
- * The path-shape arm also covers `DISCORD_API_BASE_URL` pointing at a
- * self-hosted proxy: the credential is in the path either way, so a
- * host-only rule would fail open exactly where the operator is least likely
- * to notice.
+ * The path-shape arm remains defense-in-depth for an instrumented request
+ * whose origin is unavailable or non-standard: the credential is in the path,
+ * so a host-only rule would fail open.
  */
 const DISCORD_HOST = /(^|\.)discord(app)?\.com$/i;
 /** `/webhooks/{id}/{token}` and `/interactions/{id}/{token}` carry a credential. */

--- a/packages/mcp-server/src/transports/http.test.ts
+++ b/packages/mcp-server/src/transports/http.test.ts
@@ -9,7 +9,7 @@ import { join } from 'node:path';
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { readActivity, resolveActivityPath } from '../lib/activity.js';
-import { startHttp } from './http.js';
+import { hasValidBearerToken, startHttp } from './http.js';
 
 const VALID_TOKEN = `Bot ${'a'.repeat(60)}`;
 const ACCESS_TOKEN = 'test-access-token-with-at-least-32-characters';
@@ -17,6 +17,14 @@ const savedEnv = { ...process.env };
 
 let server: Server | undefined;
 let activityRoot: string;
+
+describe('HTTP bearer parser', () => {
+  it('accepts case-insensitive schemes and rejects whitespace-only adversarial headers', () => {
+    expect(hasValidBearerToken(`bearer    ${ACCESS_TOKEN}`, ACCESS_TOKEN)).toBe(true);
+    expect(hasValidBearerToken(`Bearer ${' '.repeat(100_000)}`, ACCESS_TOKEN)).toBe(false);
+    expect(hasValidBearerToken(`Basic ${ACCESS_TOKEN}`, ACCESS_TOKEN)).toBe(false);
+  });
+});
 
 function endpoint(): URL {
   const address = server?.address() as AddressInfo | null;

--- a/packages/mcp-server/src/transports/http.ts
+++ b/packages/mcp-server/src/transports/http.ts
@@ -34,11 +34,18 @@ export interface StartHttpOptions {
   registerSignalHandlers?: boolean;
 }
 
-function hasValidBearerToken(authorization: string | undefined, expectedToken: string): boolean {
-  const match = authorization?.match(/^Bearer +(.+)$/i);
-  if (match === undefined || match === null) return false;
+export function hasValidBearerToken(
+  authorization: string | undefined,
+  expectedToken: string,
+): boolean {
+  if (authorization === undefined) return false;
+  const separator = authorization.indexOf(' ');
+  if (separator < 1 || authorization.slice(0, separator).toLowerCase() !== 'bearer') return false;
+  let tokenStart = separator + 1;
+  while (authorization[tokenStart] === ' ') tokenStart += 1;
+  if (tokenStart >= authorization.length) return false;
 
-  const suppliedToken = Buffer.from(match[1] as string);
+  const suppliedToken = Buffer.from(authorization.slice(tokenStart));
   const expected = Buffer.from(expectedToken);
   return suppliedToken.length === expected.length && timingSafeEqual(suppliedToken, expected);
 }

--- a/site/scripts/generate-tool-docs.test.ts
+++ b/site/scripts/generate-tool-docs.test.ts
@@ -83,6 +83,10 @@ describe('escapeMdx', () => {
     expect(escapeMdx('{key:value}')).toBe('\\{key:value\\}');
   });
 
+  it('escapes backslashes before MDX control characters', () => {
+    expect(escapeMdx(String.raw`\{value}\<tag>`)).toBe(String.raw`\\\{value\}\\\<tag>`);
+  });
+
   it('leaves regular text untouched', () => {
     expect(escapeMdx('plain text 123')).toBe('plain text 123');
   });

--- a/site/scripts/generate-tool-docs.ts
+++ b/site/scripts/generate-tool-docs.ts
@@ -161,7 +161,7 @@ export function parseDescription(desc: string): {
  * would otherwise try to parse as JSX expressions.
  */
 export function escapeMdx(s: string): string {
-  return s.replace(/</g, '\\<').replace(/\{/g, '\\{').replace(/\}/g, '\\}');
+  return s.replace(/\\/g, '\\\\').replace(/</g, '\\<').replace(/\{/g, '\\{').replace(/\}/g, '\\}');
 }
 
 /** Escape MDX syntax in prose without adding visible backslashes inside code spans. */

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -11,6 +11,11 @@ commit history and downloadable artifacts, see
 
 ## Unreleased
 
+- Hardened network and parsing boundaries found by the first CodeQL baseline:
+  bot credentials can no longer follow a remote `DISCORD_API_BASE_URL`, release
+  checks validate the exact GitHub repository path, npm update checks use the
+  fixed public registry endpoint, and adversarial fence/template/auth inputs
+  are handled without backtracking-prone regular expressions.
 - Updated compatible patch/minor dependencies across Discord REST, HTTP,
   validation, testing, and documentation tooling. Dependabot now keeps major
   and known Node-floor/toolchain migrations in dedicated review increments.


### PR DESCRIPTION
Hardens the confirmed findings from the first CodeQL baseline. Discord bot credentials can no longer be redirected to a remote API override or across redirects; init uses the fixed Discord endpoint; npm and GitHub release checks use validated fixed origins and reject redirects. Backtracking-prone pipeline, fence, and bearer parsing paths are replaced with linear handling while preserving legacy interpolation semantics. MDX generation now escapes backslashes before control characters. Verification: full workspace tests passed (core 1256, CLI 1232, site 119, catalog 3), full typecheck passed with zero Astro diagnostics, lint clean across 969 files, 303-page docs build passed, targeted security tests passed, and an independent review plus 200000-case differential fuzz found no interpolation regression. Two benchmark-only command findings were separately dismissed with evidence; no production alert was dismissed.