### PR TITLE
fix(site): harden generated MDX table escaping

### DIFF
--- a/site/scripts/generate-tool-docs.test.ts
+++ b/site/scripts/generate-tool-docs.test.ts
@@ -144,6 +144,24 @@ describe('renderSchemaTable', () => {
     expect(md).toMatch(/`component`.*\|\s*yes\s*\|/);
   });
 
+  it('escapes table delimiters while preserving regex and inline-code backslashes', () => {
+    const md = renderSchemaTable({
+      mode: z
+        .enum(['left', 'right'])
+        .describe('Outside \\path | code `C:\\tmp|file` and `literal\\|pipe`'),
+      image: z.string().regex(/^data:image\/(jpeg|png)$/),
+      literal: z.string().regex(/^jpeg\|png$/),
+    });
+    const escapedLiteralPipe = `literal${'\\'.repeat(3)}|pipe`;
+    const escapedLiteralPattern = `pattern: \`^jpeg${'\\'.repeat(3)}|png$\``;
+
+    expect(md).toContain('"left" \\| "right"');
+    expect(md).toContain('Outside \\\\path \\| code `C:\\tmp\\|file`');
+    expect(md).toContain(`and \`${escapedLiteralPipe}\``);
+    expect(md).toContain('pattern: `^data:image\\/(jpeg\\|png)$`');
+    expect(md).toContain(escapedLiteralPattern);
+  });
+
   it('renders the complete JSON schema for nested inspection', () => {
     const schema = renderJsonSchema({ options: z.array(z.object({ label: z.string() })) });
     expect(schema).toContain('"options"');

--- a/site/scripts/generate-tool-docs.ts
+++ b/site/scripts/generate-tool-docs.ts
@@ -172,6 +172,52 @@ export function escapeMdxProse(s: string): string {
     .join('');
 }
 
+function escapeTablePipes(s: string): string {
+  const escaped: string[] = [];
+  let precedingBackslashes = 0;
+  for (const character of s) {
+    if (character === '\\') {
+      escaped.push(character);
+      precedingBackslashes += 1;
+      continue;
+    }
+    if (character === '|') escaped.push('\\'.repeat(precedingBackslashes + 1));
+    escaped.push(character);
+    precedingBackslashes = 0;
+  }
+  return escaped.join('');
+}
+
+function escapeMdxTableCell(s: string): string {
+  const escaped: string[] = [];
+  for (const character of s) {
+    if (
+      character === '\\' ||
+      character === '<' ||
+      character === '{' ||
+      character === '}' ||
+      character === '|'
+    ) {
+      escaped.push('\\');
+    }
+    escaped.push(character);
+  }
+  return escaped.join('');
+}
+
+function escapeMdxTableProse(s: string): string {
+  return s
+    .split(/(`[^`\n]*`)/g)
+    .map((part) =>
+      part.startsWith('`') && part.endsWith('`')
+        ? escapeTablePipes(part)
+        : escapeMdxTableCell(part),
+    )
+    .join('')
+    .split('\n')
+    .join(' ');
+}
+
 type JsonSchema = Record<string, unknown>;
 
 function cleanJsonSchema(value: unknown): unknown {
@@ -263,16 +309,16 @@ export function renderSchemaTable(
     '|---|---|---|---|---|',
   ];
   for (const [name, prop] of Object.entries(props)) {
-    const type = escapeMdx(schemaType(prop)).replace(/\|/g, '\\|');
+    const type = escapeMdxTableCell(schemaType(prop));
     // z.default() is optional for callers even though Zod's output JSON Schema
     // lists it as required after default materialization.
     const req = required.has(name) && !('default' in prop) ? 'yes' : 'no';
     // Description text appears inside an MDX paragraph. Escape `<`, `{`, `}`
     // so placeholders like `<channel_id>` and `{{...}}` render as text.
-    const description = escapeMdxProse(typeof prop.description === 'string' ? prop.description : '')
-      .replace(/\|/g, '\\|')
-      .replace(/\n/g, ' ');
-    const constraints = schemaConstraints(prop).replace(/\|/g, '\\|');
+    const description = escapeMdxTableProse(
+      typeof prop.description === 'string' ? prop.description : '',
+    );
+    const constraints = escapeTablePipes(schemaConstraints(prop));
     rows.push(`| \`${name}\` | ${type} | ${req} | ${constraints} | ${description} |`);
   }
   return rows.join('\n');


### PR DESCRIPTION
Closes the three remaining CodeQL incomplete-sanitization findings in schema table rendering without changing any of the 241 generated tool-reference files. Table cells now escape MDX and pipe delimiters in linear passes; runs of backslashes before a pipe are encoded with safe odd parity so inline code and regex constraints cannot reopen a Markdown table delimiter. Verification: 41 generator tests pass, lint clean across 967 files, 303-page Astro build passes, git diff check is clean, full generator output has zero diff, and independent review found no blocker.