### PR TITLE
fix: harden local activity journal storage

### DIFF
--- a/packages/mcp-server/src/lib/activity.test.ts
+++ b/packages/mcp-server/src/lib/activity.test.ts
@@ -1,7 +1,18 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   ACTIVITY_RETENTION,
   captureActivity,
@@ -16,6 +27,7 @@ import { emitResult } from './output.js';
 let directory: string | undefined;
 
 afterEach(() => {
+  vi.restoreAllMocks();
   if (directory !== undefined) rmSync(directory, { recursive: true, force: true });
   directory = undefined;
 });
@@ -160,6 +172,205 @@ describe('activity evidence', () => {
     const events = readActivity(options);
     expect(events).toHaveLength(ACTIVITY_RETENTION);
     expect(events[0]?.at).toBe(new Date(1_700_000_000_001).toISOString());
+  });
+
+  it('does not read or write through a symlinked activity journal', ({ skip }) => {
+    const options = location();
+    const activityPath = resolveActivityPath(options);
+    const externalPath = join(directory as string, 'external.jsonl');
+    const externalEvent = `${JSON.stringify({
+      version: 1,
+      at: '2026-08-30T00:00:00.000Z',
+      command: 'setup',
+      outcome: 'success',
+      signals: ['external-sentinel'],
+    })}\n`;
+    mkdirSync(dirname(activityPath), { recursive: true });
+    writeFileSync(externalPath, externalEvent);
+    try {
+      symlinkSync(externalPath, activityPath, 'file');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EPERM') skip();
+      throw error;
+    }
+
+    expect(readActivity(options)).toEqual([]);
+    recordActivity(
+      {
+        version: 1,
+        at: '2026-08-30T01:00:00.000Z',
+        command: 'doctor',
+        outcome: 'failure',
+        signals: ['must-not-be-written'],
+      },
+      options,
+    );
+
+    expect(lstatSync(activityPath).isSymbolicLink()).toBe(true);
+    expect(readFileSync(externalPath, 'utf8')).toBe(externalEvent);
+  });
+
+  it('does not read or write through a symlinked activity directory', ({ skip }) => {
+    location();
+    const externalDirectory = join(directory as string, 'external-activity');
+    const linkedDirectory = join(directory as string, 'linked-activity');
+    const options = { directory: join(linkedDirectory, 'profiles') };
+    const externalPath = join(externalDirectory, 'activity.jsonl');
+    mkdirSync(externalDirectory);
+    writeFileSync(
+      externalPath,
+      `${JSON.stringify({
+        version: 1,
+        at: '2026-08-30T00:00:00.000Z',
+        command: 'setup',
+        outcome: 'success',
+        signals: ['external-sentinel'],
+      })}\n`,
+    );
+    try {
+      symlinkSync(externalDirectory, linkedDirectory, 'junction');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EPERM') skip();
+      throw error;
+    }
+
+    expect(readActivity(options)).toEqual([]);
+    recordActivity(
+      {
+        version: 1,
+        at: '2026-08-30T01:00:00.000Z',
+        command: 'doctor',
+        outcome: 'failure',
+        signals: ['must-not-be-written'],
+      },
+      options,
+    );
+
+    expect(lstatSync(linkedDirectory).isSymbolicLink()).toBe(true);
+    expect(readFileSync(externalPath, 'utf8')).not.toContain('must-not-be-written');
+  });
+
+  it('skips a concurrent writer while preserving its live lock', () => {
+    const options = location();
+    const activityPath = resolveActivityPath(options);
+    const lockPath = join(dirname(activityPath), '.activity.lock');
+    mkdirSync(dirname(activityPath), { recursive: true });
+    writeFileSync(lockPath, 'other-process\n');
+
+    recordActivity(
+      {
+        version: 1,
+        at: '2026-08-30T01:00:00.000Z',
+        command: 'doctor',
+        outcome: 'success',
+        signals: [],
+      },
+      options,
+    );
+
+    expect(readActivity(options)).toEqual([]);
+    expect(readFileSync(lockPath, 'utf8')).toBe('other-process\n');
+  });
+
+  it('reclaims an unchanged stale lock before recording', () => {
+    const options = location();
+    const activityPath = resolveActivityPath(options);
+    const lockPath = join(dirname(activityPath), '.activity.lock');
+    mkdirSync(dirname(activityPath), { recursive: true });
+    writeFileSync(lockPath, '424242\n');
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockPath, stale, stale);
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('process not found'), { code: 'ESRCH' });
+    });
+
+    recordActivity(
+      {
+        version: 1,
+        at: '2026-08-30T01:00:00.000Z',
+        command: 'doctor',
+        outcome: 'success',
+        signals: [],
+      },
+      options,
+    );
+
+    expect(readActivity(options)).toHaveLength(1);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('does not reclaim an old lock while its owner is still alive', () => {
+    const options = location();
+    const activityPath = resolveActivityPath(options);
+    const lockPath = join(dirname(activityPath), '.activity.lock');
+    mkdirSync(dirname(activityPath), { recursive: true });
+    writeFileSync(lockPath, `${process.pid}\n`);
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockPath, stale, stale);
+    const kill = vi.spyOn(process, 'kill').mockReturnValue(true);
+
+    recordActivity(
+      {
+        version: 1,
+        at: '2026-08-30T01:00:00.000Z',
+        command: 'doctor',
+        outcome: 'success',
+        signals: [],
+      },
+      options,
+    );
+
+    expect(kill).toHaveBeenCalledWith(process.pid, 0);
+    expect(readActivity(options)).toEqual([]);
+    expect(existsSync(lockPath)).toBe(true);
+  });
+
+  it('does not read or reclaim an oversized stale lock', () => {
+    const options = location();
+    const activityPath = resolveActivityPath(options);
+    const lockPath = join(dirname(activityPath), '.activity.lock');
+    mkdirSync(dirname(activityPath), { recursive: true });
+    writeFileSync(lockPath, Buffer.alloc(64, 0x31));
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockPath, stale, stale);
+    const kill = vi.spyOn(process, 'kill');
+
+    recordActivity(
+      {
+        version: 1,
+        at: '2026-08-30T01:00:00.000Z',
+        command: 'doctor',
+        outcome: 'success',
+        signals: [],
+      },
+      options,
+    );
+
+    expect(kill).not.toHaveBeenCalled();
+    expect(readActivity(options)).toEqual([]);
+    expect(statSync(lockPath).size).toBe(64);
+  });
+
+  it('does not append beyond the bounded journal size', () => {
+    const options = location();
+    const activityPath = resolveActivityPath(options);
+    mkdirSync(dirname(activityPath), { recursive: true });
+    writeFileSync(activityPath, Buffer.alloc(1024 * 1024 + 1, 0x78));
+    const before = statSync(activityPath).size;
+
+    recordActivity(
+      {
+        version: 1,
+        at: '2026-08-30T01:00:00.000Z',
+        command: 'doctor',
+        outcome: 'success',
+        signals: [],
+      },
+      options,
+    );
+
+    expect(statSync(activityPath).size).toBe(before);
+    expect(readActivity(options)).toEqual([]);
   });
 
   it('uses XDG_CONFIG_HOME for the Linux journal location', () => {

--- a/packages/mcp-server/src/lib/activity.ts
+++ b/packages/mcp-server/src/lib/activity.ts
@@ -7,7 +7,23 @@
  * setup, doctor, smoke, and blueprint lifecycle calls are succeeding before
  * the project makes broader onboarding and adoption decisions.
  */
-import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import {
+  appendFileSync,
+  closeSync,
+  constants as fsConstants,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  type Stats,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { BlueprintLifecycleObservation } from '@discord-mcp/core';
 import type { CommandResult } from './output.js';
@@ -17,6 +33,11 @@ const ACTIVITY_VERSION = 1;
 const BLUEPRINT_ACTIVITY_VERSION = 2;
 export const ACTIVITY_RETENTION = 200;
 const RECENT_ACTIVITY_LIMIT = 10;
+const MAX_ACTIVITY_BYTES = 1024 * 1024;
+const ACTIVITY_FILE_NAME = 'activity.jsonl';
+const ACTIVITY_LOCK_NAME = '.activity.lock';
+const ACTIVITY_LOCK_STALE_MS = 30_000;
+const MAX_ACTIVITY_LOCK_BYTES = 32;
 const ACTIVITY_COMMANDS = ['setup', 'doctor', 'smoke'] as const;
 const ACTIVITY_OUTCOMES = ['success', 'warning', 'failure'] as const;
 const BLUEPRINT_ACTIVITY_STAGES = ['plan', 'apply', 'evidence'] as const;
@@ -152,6 +173,7 @@ function parseActivityEvent(value: unknown): ActivityEvent | undefined {
     !isActivityCommand(record.command) ||
     !isActivityOutcome(record.outcome) ||
     !Array.isArray(record.signals) ||
+    record.signals.length > 64 ||
     record.signals.some((signal) => typeof signal !== 'string' || signal.length > 80)
   ) {
     return undefined;
@@ -166,50 +188,306 @@ function parseActivityEvent(value: unknown): ActivityEvent | undefined {
 }
 
 export function resolveActivityPath(options: ProfileLocationOptions = {}): string {
-  return join(dirname(resolveProfileDirectory(options)), 'activity.jsonl');
+  return join(dirname(resolveProfileDirectory(options)), ACTIVITY_FILE_NAME);
+}
+
+function missing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT';
+}
+
+function sameFileIdentity(expected: Stats, actual: Stats): boolean {
+  if (expected.ino !== actual.ino || expected.ino === 0) return false;
+  if (expected.dev === actual.dev) return true;
+  return process.platform === 'win32' && (expected.dev === 0 || actual.dev === 0);
+}
+
+function canonicalActivityDirectory(directory: string): string | undefined {
+  let metadata: Stats;
+  try {
+    metadata = lstatSync(directory);
+  } catch (error) {
+    if (missing(error)) return undefined;
+    throw error;
+  }
+  if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+    throw new Error('Activity directory must be a regular directory');
+  }
+  return realpathSync(directory);
+}
+
+function ensureActivityDirectory(directory: string): string {
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const canonical = canonicalActivityDirectory(directory);
+  if (canonical === undefined) {
+    throw new Error('Activity directory disappeared while opening');
+  }
+  return canonical;
+}
+
+function inspectActivityFile(path: string): Stats | undefined {
+  let metadata: Stats;
+  try {
+    metadata = lstatSync(path);
+  } catch (error) {
+    if (missing(error)) return undefined;
+    throw error;
+  }
+  if (metadata.isSymbolicLink() || !metadata.isFile() || metadata.size > MAX_ACTIVITY_BYTES) {
+    throw new Error('Activity journal must be a bounded regular file');
+  }
+  return metadata;
+}
+
+function openVerifiedActivity(path: string, flags: number): number | undefined {
+  const expected = inspectActivityFile(path);
+  if (expected === undefined) return undefined;
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(path, flags | (fsConstants.O_NOFOLLOW ?? 0));
+    const actual = fstatSync(descriptor);
+    if (!actual.isFile() || !sameFileIdentity(expected, actual)) {
+      throw new Error('Activity journal changed while opening');
+    }
+    return descriptor;
+  } catch (error) {
+    if (descriptor !== undefined) closeSync(descriptor);
+    throw error;
+  }
+}
+
+function openActivityForAppend(path: string): number {
+  const existing = openVerifiedActivity(path, fsConstants.O_WRONLY | fsConstants.O_APPEND);
+  if (existing !== undefined) return existing;
+
+  try {
+    const descriptor = openSync(
+      path,
+      fsConstants.O_WRONLY |
+        fsConstants.O_APPEND |
+        fsConstants.O_CREAT |
+        fsConstants.O_EXCL |
+        (fsConstants.O_NOFOLLOW ?? 0),
+      0o600,
+    );
+    try {
+      if (!fstatSync(descriptor).isFile()) throw new Error('Activity journal is not a file');
+      return descriptor;
+    } catch (error) {
+      closeSync(descriptor);
+      throw error;
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code !== 'EEXIST') throw error;
+    const raced = openVerifiedActivity(path, fsConstants.O_WRONLY | fsConstants.O_APPEND);
+    if (raced === undefined) throw new Error('Activity journal disappeared while opening');
+    return raced;
+  }
+}
+
+function readActivityText(path: string): string | undefined {
+  const descriptor = openVerifiedActivity(path, fsConstants.O_RDONLY);
+  if (descriptor === undefined) return undefined;
+  try {
+    return readFileSync(descriptor, 'utf8');
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function parseActivityText(text: string): ActivityEvent[] {
+  return text
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .flatMap((line) => {
+      try {
+        const event = parseActivityEvent(JSON.parse(line));
+        return event === undefined ? [] : [event];
+      } catch {
+        return [];
+      }
+    });
+}
+
+interface ActivityLock {
+  readonly path: string;
+  readonly identity: Stats;
+}
+
+function createActivityLock(path: string): ActivityLock | undefined {
+  let descriptor: number;
+  try {
+    descriptor = openSync(
+      path,
+      fsConstants.O_WRONLY |
+        fsConstants.O_CREAT |
+        fsConstants.O_EXCL |
+        (fsConstants.O_NOFOLLOW ?? 0),
+      0o600,
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code === 'EEXIST') return undefined;
+    throw error;
+  }
+  try {
+    writeFileSync(descriptor, `${process.pid}\n`, { encoding: 'utf8' });
+    fsyncSync(descriptor);
+    const identity = fstatSync(descriptor);
+    if (!identity.isFile()) throw new Error('Activity lock is not a regular file');
+    return { path, identity };
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function reclaimStaleActivityLock(path: string): boolean {
+  let first: Stats;
+  try {
+    first = lstatSync(path);
+  } catch (error) {
+    if (missing(error)) return false;
+    throw error;
+  }
+  if (
+    first.isSymbolicLink() ||
+    !first.isFile() ||
+    first.size > MAX_ACTIVITY_LOCK_BYTES ||
+    Date.now() - first.mtimeMs <= ACTIVITY_LOCK_STALE_MS
+  ) {
+    return false;
+  }
+  let descriptor: number | undefined;
+  let ownerText: string;
+  try {
+    descriptor = openSync(path, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
+    const opened = fstatSync(descriptor);
+    if (!opened.isFile() || !sameFileIdentity(first, opened)) return false;
+    ownerText = readFileSync(descriptor, 'utf8').trim();
+  } catch (error) {
+    if (missing(error)) return false;
+    throw error;
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+  const ownerPid = Number(ownerText);
+  if (!/^\d{1,10}$/.test(ownerText) || !Number.isSafeInteger(ownerPid) || ownerPid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(ownerPid, 0);
+    return false;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code !== 'ESRCH') return false;
+  }
+  let current: Stats;
+  try {
+    current = lstatSync(path);
+  } catch (error) {
+    if (missing(error)) return false;
+    throw error;
+  }
+  if (!sameFileIdentity(first, current)) return false;
+  unlinkSync(path);
+  return true;
+}
+
+function acquireActivityLock(directory: string): ActivityLock {
+  const path = join(directory, ACTIVITY_LOCK_NAME);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const lock = createActivityLock(path);
+    if (lock !== undefined) return lock;
+    if (attempt === 0 && reclaimStaleActivityLock(path)) continue;
+    break;
+  }
+  throw new Error('Activity journal is busy');
+}
+
+function releaseActivityLock(lock: ActivityLock): void {
+  let current: Stats;
+  try {
+    current = lstatSync(lock.path);
+  } catch (error) {
+    if (missing(error)) return;
+    throw error;
+  }
+  if (current.isSymbolicLink() || !sameFileIdentity(lock.identity, current)) return;
+  unlinkSync(lock.path);
 }
 
 export function readActivity(options: ProfileLocationOptions = {}): ActivityEvent[] {
-  const path = resolveActivityPath(options);
-  if (!existsSync(path)) return [];
+  const requested = resolveActivityPath(options);
   try {
-    return readFileSync(path, 'utf8')
-      .split('\n')
-      .filter((line) => line.length > 0)
-      .flatMap((line) => {
-        try {
-          const event = parseActivityEvent(JSON.parse(line));
-          return event === undefined ? [] : [event];
-        } catch {
-          return [];
-        }
-      });
+    const directory = canonicalActivityDirectory(dirname(requested));
+    if (directory === undefined) return [];
+    return parseActivityText(readActivityText(join(directory, ACTIVITY_FILE_NAME)) ?? '');
   } catch {
     return [];
   }
 }
 
-function writeActivity(events: readonly ActivityEvent[], options: ProfileLocationOptions): void {
-  const path = resolveActivityPath(options);
-  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-  writeFileSync(path, `${events.map((event) => JSON.stringify(event)).join('\n')}\n`, {
-    encoding: 'utf8',
-    mode: 0o600,
-  });
+function writeActivity(events: readonly ActivityEvent[], path: string, directory: string): void {
+  inspectActivityFile(path);
+  const content = `${events.map((event) => JSON.stringify(event)).join('\n')}\n`;
+  if (Buffer.byteLength(content, 'utf8') > MAX_ACTIVITY_BYTES) {
+    throw new Error('Compacted activity journal is too large');
+  }
+  const temporary = join(directory, `.activity.${process.pid}.${randomUUID()}.tmp`);
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(
+      temporary,
+      fsConstants.O_WRONLY |
+        fsConstants.O_CREAT |
+        fsConstants.O_EXCL |
+        (fsConstants.O_NOFOLLOW ?? 0),
+      0o600,
+    );
+    writeFileSync(descriptor, content, { encoding: 'utf8' });
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = undefined;
+    inspectActivityFile(path);
+    renameSync(temporary, path);
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+    try {
+      unlinkSync(temporary);
+    } catch {
+      // Best-effort cleanup must not replace the original journal error.
+    }
+  }
 }
 
 export function recordActivity(event: ActivityEvent, options: ProfileLocationOptions = {}): void {
   try {
-    const existing = readActivity(options);
-    const retained = [...existing, event].slice(-ACTIVITY_RETENTION);
-    if (existing.length >= ACTIVITY_RETENTION) {
-      writeActivity(retained, options);
-      return;
-    }
+    const normalized = parseActivityEvent(event);
+    if (normalized === undefined) return;
+    const requested = resolveActivityPath(options);
+    const directory = ensureActivityDirectory(dirname(requested));
+    const path = join(directory, ACTIVITY_FILE_NAME);
+    const lock = acquireActivityLock(directory);
+    try {
+      const existing = parseActivityText(readActivityText(path) ?? '');
+      const retained = [...existing, normalized].slice(-ACTIVITY_RETENTION);
+      if (existing.length >= ACTIVITY_RETENTION) {
+        writeActivity(retained, path, directory);
+        return;
+      }
 
-    const path = resolveActivityPath(options);
-    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-    appendFileSync(path, `${JSON.stringify(event)}\n`, { encoding: 'utf8', mode: 0o600 });
+      const line = `${JSON.stringify(normalized)}\n`;
+      const descriptor = openActivityForAppend(path);
+      try {
+        const currentSize = fstatSync(descriptor).size;
+        if (currentSize + Buffer.byteLength(line, 'utf8') > MAX_ACTIVITY_BYTES) {
+          throw new Error('Activity journal is too large');
+        }
+        appendFileSync(descriptor, line, { encoding: 'utf8' });
+        fsyncSync(descriptor);
+      } finally {
+        closeSync(descriptor);
+      }
+    } finally {
+      releaseActivityLock(lock);
+    }
   } catch {
     // Activity evidence must never change a command's visible result.
   }

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -16,6 +16,9 @@ commit history and downloadable artifacts, see
   checks validate the exact GitHub repository path, npm update checks use the
   fixed public registry endpoint, and adversarial fence/template/auth inputs
   are handled without backtracking-prone regular expressions.
+- Hardened the local activity journal against symlink redirection, cross-process
+  compaction races, oversized files, and stale-lock reclamation while keeping
+  activity evidence best-effort and local-only.
 - Updated compatible patch/minor dependencies across Discord REST, HTTP,
   validation, testing, and documentation tooling. Dependabot now keeps major
   and known Node-floor/toolchain migrations in dedicated review increments.


### PR DESCRIPTION
Hardens the local-only activity journal after CodeQL path review found real symlink write sinks. Reads and appends now use bounded regular-file checks, descriptor identity, and no-follow flags where available; directory targets are canonicalized once per operation; append and compaction are serialized with an exclusive owner-aware lock; stale locks are reclaimed only after bounded parsing and dead-PID proof; append and compact payloads are byte-bounded. Verification: full CLI suite 1225 passed / 10 skipped / 1 todo; focused activity tests 17 passed / 1 Windows file-symlink fixture skipped; native Windows retention compaction repeatedly preserved the newest 200 of 201 records; CLI typecheck and lint across 967 files pass; independent review found no remaining P1/P2 blocker.