### PR TITLE
fix: harden local profile storage boundaries

### DIFF
--- a/packages/mcp-server/src/lib/profiles.test.ts
+++ b/packages/mcp-server/src/lib/profiles.test.ts
@@ -1,4 +1,12 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -9,6 +17,7 @@ import {
   loadProfile,
   normalizeProfileCategories,
   normalizeProfileName,
+  profileExists,
   profilePath,
   removeProfile,
   resolveProfileDirectory,
@@ -147,6 +156,67 @@ describe('profile storage', () => {
     removeProfile('remove', { directory });
 
     expect(listProfiles({ directory }).map((item) => item.name)).toEqual(['keep']);
+  });
+
+  it('rejects profile file symlinks without reading, replacing, or removing their target', ({
+    skip,
+  }) => {
+    const externalDirectory = join(directory, 'external');
+    const externalPath = join(externalDirectory, 'devbot.json');
+    const target = profilePath('devbot', { directory });
+    const externalContent = JSON.stringify(profile());
+    mkdirSync(externalDirectory);
+    writeFileSync(externalPath, externalContent, 'utf8');
+    try {
+      symlinkSync(externalPath, target, 'file');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EPERM') skip();
+      throw error;
+    }
+
+    expect(() => profileExists('devbot', { directory })).toThrow('bounded regular file');
+    expect(() => loadProfile('devbot', { directory })).toThrow('bounded regular file');
+    expect(() => saveProfile(profile(), { directory, overwrite: true })).toThrow(
+      'bounded regular file',
+    );
+    expect(() => removeProfile('devbot', { directory })).toThrow('bounded regular file');
+    expect(listProfiles({ directory })).toEqual([]);
+    expect(lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(readFileSync(externalPath, 'utf8')).toBe(externalContent);
+  });
+
+  it('rejects a symlinked profile directory without touching its contents', ({ skip }) => {
+    const externalDirectory = join(directory, 'external-profiles');
+    const linkedDirectory = join(directory, 'linked-profiles');
+    const externalPath = join(externalDirectory, 'devbot.json');
+    const externalContent = JSON.stringify(profile());
+    mkdirSync(externalDirectory);
+    writeFileSync(externalPath, externalContent, 'utf8');
+    try {
+      symlinkSync(externalDirectory, linkedDirectory, 'junction');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EPERM') skip();
+      throw error;
+    }
+
+    const options = { directory: linkedDirectory };
+    expect(() => profileExists('devbot', options)).toThrow('regular directory');
+    expect(() => loadProfile('devbot', options)).toThrow('regular directory');
+    expect(() => listProfiles(options)).toThrow('regular directory');
+    expect(() => saveProfile(profile(), { ...options, overwrite: true })).toThrow(
+      'regular directory',
+    );
+    expect(() => removeProfile('devbot', options)).toThrow('regular directory');
+    expect(lstatSync(linkedDirectory).isSymbolicLink()).toBe(true);
+    expect(readFileSync(externalPath, 'utf8')).toBe(externalContent);
+  });
+
+  it('rejects oversized profile files by UTF-8 bytes before parsing them', () => {
+    const path = profilePath('devbot', { directory });
+    writeFileSync(path, 'é'.repeat(512 * 1024 + 1), 'utf8');
+
+    expect(() => profileExists('devbot', { directory })).toThrow('bounded regular file');
+    expect(() => loadProfile('devbot', { directory })).toThrow('bounded regular file');
   });
 });
 

--- a/packages/mcp-server/src/lib/profiles.ts
+++ b/packages/mcp-server/src/lib/profiles.ts
@@ -1,11 +1,18 @@
 import { randomUUID } from 'node:crypto';
 import {
-  existsSync,
+  closeSync,
+  constants as fsConstants,
+  fstatSync,
+  fsyncSync,
   linkSync,
+  lstatSync,
   mkdirSync,
+  openSync,
   readdirSync,
-  readFileSync,
+  readSync,
+  realpathSync,
   renameSync,
+  type Stats,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -30,6 +37,7 @@ const CLIENT_IDS = [
 const TOOL_SURFACES = ['full', 'progressive'] as const;
 const WRITE_MODES = ['allow', 'preview'] as const;
 const PROFILE_CATEGORY = /^[a-z][a-z0-9_]*$/;
+const MAX_PROFILE_BYTES = 1024 * 1024;
 
 export type ProfileClientId = (typeof CLIENT_IDS)[number];
 export type ProfileToolSurface = (typeof TOOL_SURFACES)[number];
@@ -233,18 +241,96 @@ export function profilePath(name: string, options: ProfileLocationOptions = {}):
   return join(resolveProfileDirectory(options), `${normalizeProfileName(name)}.json`);
 }
 
-export function profileExists(name: string, options: ProfileLocationOptions = {}): boolean {
-  return existsSync(profilePath(name, options));
+function missing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT';
 }
 
-export function loadProfile(name: string, options: ProfileLocationOptions = {}): DiscordMcpProfile {
-  const normalizedName = normalizeProfileName(name);
-  const path = profilePath(normalizedName, options);
-  if (!existsSync(path)) throw new Error(`Profile not found: ${normalizedName}`);
+function sameFileIdentity(expected: Stats, actual: Stats): boolean {
+  if (expected.ino !== actual.ino || expected.ino === 0) return false;
+  if (expected.dev === actual.dev) return true;
+  return process.platform === 'win32' && (expected.dev === 0 || actual.dev === 0);
+}
 
+// The directory path is caller-owned. Resolve its selected ancestor chain once,
+// but reject a final symlink/junction so each operation uses a stable directory.
+function canonicalProfileDirectory(directory: string): string | undefined {
+  let metadata: Stats;
+  try {
+    metadata = lstatSync(directory);
+  } catch (error) {
+    if (missing(error)) return undefined;
+    throw error;
+  }
+  if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+    throw new Error('Profile directory must be a regular directory');
+  }
+  return realpathSync(directory);
+}
+
+function ensureProfileDirectory(directory: string): string {
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const canonical = canonicalProfileDirectory(directory);
+  if (canonical === undefined) throw new Error('Profile directory disappeared while opening');
+  return canonical;
+}
+
+function inspectProfileFile(path: string): Stats | undefined {
+  let metadata: Stats;
+  try {
+    metadata = lstatSync(path);
+  } catch (error) {
+    if (missing(error)) return undefined;
+    throw error;
+  }
+  if (metadata.isSymbolicLink() || !metadata.isFile() || metadata.size > MAX_PROFILE_BYTES) {
+    throw new Error('Profile must be a bounded regular file');
+  }
+  return metadata;
+}
+
+function readDescriptorBounded(descriptor: number): string {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  while (total <= MAX_PROFILE_BYTES) {
+    const chunk = Buffer.allocUnsafe(Math.min(64 * 1024, MAX_PROFILE_BYTES + 1 - total));
+    const bytesRead = readSync(descriptor, chunk, 0, chunk.length, null);
+    if (bytesRead === 0) break;
+    chunks.push(chunk.subarray(0, bytesRead));
+    total += bytesRead;
+  }
+  if (total > MAX_PROFILE_BYTES) throw new Error('Profile must be a bounded regular file');
+  return Buffer.concat(chunks, total).toString('utf8');
+}
+
+interface StoredProfile {
+  readonly text: string;
+  readonly identity: Stats;
+}
+
+function readStoredProfile(path: string): StoredProfile | undefined {
+  const expected = inspectProfileFile(path);
+  if (expected === undefined) return undefined;
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(path, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
+    const actual = fstatSync(descriptor);
+    if (
+      !actual.isFile() ||
+      actual.size > MAX_PROFILE_BYTES ||
+      !sameFileIdentity(expected, actual)
+    ) {
+      throw new Error('Profile changed while opening');
+    }
+    return { text: readDescriptorBounded(descriptor), identity: actual };
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function parseStoredProfile(stored: StoredProfile, normalizedName: string): DiscordMcpProfile {
   let value: unknown;
   try {
-    value = JSON.parse(readFileSync(path, 'utf8'));
+    value = JSON.parse(stored.text);
   } catch (error) {
     throw new Error(
       `Cannot read profile ${normalizedName}: ${error instanceof Error ? error.message : String(error)}`,
@@ -253,21 +339,59 @@ export function loadProfile(name: string, options: ProfileLocationOptions = {}):
   return parseProfileValue(value, normalizedName);
 }
 
+function storedProfilePath(directory: string, normalizedName: string): string {
+  return join(directory, `${normalizedName}.json`);
+}
+
+export function profileExists(name: string, options: ProfileLocationOptions = {}): boolean {
+  const normalizedName = normalizeProfileName(name);
+  const directory = canonicalProfileDirectory(resolveProfileDirectory(options));
+  return (
+    directory !== undefined &&
+    inspectProfileFile(storedProfilePath(directory, normalizedName)) !== undefined
+  );
+}
+
+export function loadProfile(name: string, options: ProfileLocationOptions = {}): DiscordMcpProfile {
+  const normalizedName = normalizeProfileName(name);
+  let stored: StoredProfile | undefined;
+  try {
+    const directory = canonicalProfileDirectory(resolveProfileDirectory(options));
+    stored =
+      directory === undefined
+        ? undefined
+        : readStoredProfile(storedProfilePath(directory, normalizedName));
+  } catch (error) {
+    throw new Error(
+      `Cannot read profile ${normalizedName}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (stored === undefined) throw new Error(`Profile not found: ${normalizedName}`);
+  return parseStoredProfile(stored, normalizedName);
+}
+
 export function listProfiles(options: ProfileLocationOptions = {}): DiscordMcpProfile[] {
-  const directory = resolveProfileDirectory(options);
-  if (!existsSync(directory)) return [];
+  const directory = canonicalProfileDirectory(resolveProfileDirectory(options));
+  if (directory === undefined) return [];
   return readdirSync(directory, { withFileTypes: true })
     .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
-    .map((entry) => loadProfile(basename(entry.name, '.json'), options))
+    .map((entry) => {
+      const normalizedName = normalizeProfileName(basename(entry.name, '.json'));
+      const stored = readStoredProfile(storedProfilePath(directory, normalizedName));
+      if (stored === undefined) throw new Error(`Profile not found: ${normalizedName}`);
+      return parseStoredProfile(stored, normalizedName);
+    })
     .sort((left, right) => left.name.localeCompare(right.name));
 }
 
 export function saveProfile(profile: DiscordMcpProfile, options: SaveProfileOptions = {}): string {
   const validated = parseProfileValue(profile);
-  const target = profilePath(validated.name, options);
-  const targetExisted = existsSync(target);
-  if (targetExisted) {
-    const current = loadProfile(validated.name, options);
+  const requestedTarget = profilePath(validated.name, options);
+  const directory = ensureProfileDirectory(resolveProfileDirectory(options));
+  const target = storedProfilePath(directory, validated.name);
+  const existing = readStoredProfile(target);
+  if (existing !== undefined) {
+    const current = parseStoredProfile(existing, validated.name);
     if (options.overwrite !== true) {
       throw new Error(`Profile ${validated.name} already exists; use --force to update it`);
     }
@@ -278,16 +402,48 @@ export function saveProfile(profile: DiscordMcpProfile, options: SaveProfileOpti
     }
   }
 
-  const directory = resolveProfileDirectory(options);
-  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const content = `${JSON.stringify(validated, null, 2)}\n`;
+  if (Buffer.byteLength(content, 'utf8') > MAX_PROFILE_BYTES) {
+    throw new Error('Profile must be a bounded regular file');
+  }
   const temporary = join(directory, `.${validated.name}.${process.pid}.${randomUUID()}.tmp`);
+  let descriptor: number | undefined;
+  let temporaryIdentity: Stats | undefined;
   try {
-    writeFileSync(temporary, `${JSON.stringify(validated, null, 2)}\n`, {
-      encoding: 'utf8',
-      flag: 'wx',
-      mode: 0o600,
-    });
-    if (targetExisted) {
+    descriptor = openSync(
+      temporary,
+      fsConstants.O_WRONLY |
+        fsConstants.O_CREAT |
+        fsConstants.O_EXCL |
+        (fsConstants.O_NOFOLLOW ?? 0),
+      0o600,
+    );
+    temporaryIdentity = fstatSync(descriptor);
+    if (!temporaryIdentity.isFile()) throw new Error('Profile temporary file is unsafe');
+    writeFileSync(descriptor, content, { encoding: 'utf8' });
+    fsyncSync(descriptor);
+    const written = fstatSync(descriptor);
+    if (
+      !written.isFile() ||
+      written.size > MAX_PROFILE_BYTES ||
+      !sameFileIdentity(temporaryIdentity, written)
+    ) {
+      throw new Error('Profile temporary file is unsafe');
+    }
+    closeSync(descriptor);
+    descriptor = undefined;
+
+    const prepared = inspectProfileFile(temporary);
+    if (prepared === undefined || !sameFileIdentity(temporaryIdentity, prepared)) {
+      throw new Error('Profile temporary file changed before publishing');
+    }
+    if (existing !== undefined) {
+      const current = inspectProfileFile(target);
+      if (current === undefined || !sameFileIdentity(existing.identity, current)) {
+        throw new Error(
+          `Profile ${validated.name} changed while updating; inspect it before retrying`,
+        );
+      }
       renameSync(temporary, target);
     } else {
       try {
@@ -300,19 +456,47 @@ export function saveProfile(profile: DiscordMcpProfile, options: SaveProfileOpti
         }
         throw error;
       }
+      const published = inspectProfileFile(target);
+      if (published === undefined || !sameFileIdentity(temporaryIdentity, published)) {
+        throw new Error(`Profile ${validated.name} changed while publishing`);
+      }
     }
   } finally {
-    if (existsSync(temporary)) unlinkSync(temporary);
+    if (descriptor !== undefined) closeSync(descriptor);
+    if (temporaryIdentity !== undefined) {
+      try {
+        const current = lstatSync(temporary);
+        if (
+          !current.isSymbolicLink() &&
+          current.isFile() &&
+          sameFileIdentity(temporaryIdentity, current)
+        ) {
+          unlinkSync(temporary);
+        }
+      } catch (error) {
+        if (!missing(error)) {
+          // Best-effort cleanup must not replace the profile operation result.
+        }
+      }
+    }
   }
-  return target;
+  return requestedTarget;
 }
 
 export function removeProfile(name: string, options: ProfileLocationOptions = {}): string {
   const normalizedName = normalizeProfileName(name);
-  const target = profilePath(normalizedName, options);
-  if (!existsSync(target)) throw new Error(`Profile not found: ${normalizedName}`);
+  const requestedTarget = profilePath(normalizedName, options);
+  const directory = canonicalProfileDirectory(resolveProfileDirectory(options));
+  if (directory === undefined) throw new Error(`Profile not found: ${normalizedName}`);
+  const target = storedProfilePath(directory, normalizedName);
+  const expected = inspectProfileFile(target);
+  if (expected === undefined) throw new Error(`Profile not found: ${normalizedName}`);
+  const current = inspectProfileFile(target);
+  if (current === undefined || !sameFileIdentity(expected, current)) {
+    throw new Error(`Profile ${normalizedName} changed while removing; inspect it before retrying`);
+  }
   unlinkSync(target);
-  return target;
+  return requestedTarget;
 }
 
 export function activateProfile(

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -22,6 +22,10 @@ commit history and downloadable artifacts, see
 - Hardened blueprint checkpoint, Activity Evidence, and apply-lock reads with
   bounded descriptor I/O, regular-file identity checks, symlink rejection, and
   descriptor-verified publication permissions.
+- Hardened local profile storage with bounded descriptor reads, regular-file
+  identity checks, atomic exclusive publication, and final profile
+  file/directory symlink rejection. Profile metadata and command behavior
+  remain unchanged.
 - Updated compatible patch/minor dependencies across Discord REST, HTTP,
   validation, testing, and documentation tooling. Dependabot now keeps major
   and known Node-floor/toolchain migrations in dedicated review increments.


### PR DESCRIPTION
## Summary
- reject final profile directory junctions/symlinks and profile file symlinks/non-files
- read profile JSON through bounded, identity-verified descriptors with a 1 MiB UTF-8 limit
- preserve bot locks and exclusive atomic publication while rechecking file identity
- add Windows-aware regression coverage and document the hardening

## Security boundary
The profile directory is caller-selected. Its selected ancestor chain is canonicalized once per operation; the final profile directory and profile files must be regular, non-symlink entries.

## Verification
- `pnpm --filter @discord-mcp/cli exec vitest run src/lib/profiles.test.ts` (19 passed, 1 Windows privilege skip)
- `pnpm --filter @discord-mcp/cli test` (1232 passed, 11 skipped, 1 todo)
- `pnpm --filter @discord-mcp/cli typecheck`
- `pnpm exec biome check packages/mcp-server/src/lib/profiles.ts packages/mcp-server/src/lib/profiles.test.ts`
- `pnpm --filter site build` (303 pages; navigation verified)
- `git diff --check`