### PR TITLE
fix: retry transient Windows quota lock errors

### DIFF
--- a/packages/mcp-core/src/tools/guild/_lib/blueprint.plan-reference-store.ts
+++ b/packages/mcp-core/src/tools/guild/_lib/blueprint.plan-reference-store.ts
@@ -19,7 +19,7 @@ const MAX_ENVELOPE_BYTES = 1_048_576;
 const MAX_REFERENCE_RECORDS = 256;
 const MAX_REFERENCE_TOTAL_BYTES = 64 * 1024 * 1024;
 const QUOTA_LOCK_RETRY_MS = 10;
-const QUOTA_LOCK_TIMEOUT_MS = 5_000;
+const QUOTA_LOCK_TIMEOUT_MS = 15_000;
 const QUOTA_LOCK_STALE_MS = 30_000;
 const MAX_QUOTA_LOCK_BYTES = 4_096;
 
@@ -108,6 +108,16 @@ function isMissing(error: unknown): boolean {
 
 function isAlreadyExists(error: unknown): boolean {
   return error instanceof Error && 'code' in error && error.code === 'EEXIST';
+}
+
+function isRetryableQuotaLockError(error: unknown): boolean {
+  return (
+    isAlreadyExists(error) ||
+    (process.platform === 'win32' &&
+      error instanceof Error &&
+      'code' in error &&
+      ['EACCES', 'EBUSY', 'EPERM'].includes(String(error.code)))
+  );
 }
 
 function wait(milliseconds: number): Promise<void> {
@@ -470,38 +480,44 @@ async function withQuotaLock<T>(directory: string, operation: () => Promise<T>):
       await chmodSecure(lockPath, 0o600);
       break;
     } catch (error) {
-      if (!isAlreadyExists(error)) {
+      if (!isRetryableQuotaLockError(error)) {
         throw new BlueprintPlanReferenceStoreError(
           'PLAN_REFERENCE_IO',
           'Plan reference storage is unavailable.',
         );
       }
-      try {
-        const existing = await readQuotaLock(lockPath);
-        if (existing !== null && isStaleQuotaLock(existing)) {
-          // Match the checkpoint-store lock discipline: a malformed, live, or
-          // replaced record is never reclaimed. The second read narrows the
-          // stale-owner race before the exclusive-create retry below.
-          const confirmed = await readQuotaLock(lockPath);
-          if (
-            confirmed !== null &&
-            confirmed.record.nonce === existing.record.nonce &&
-            confirmed.metadata.ino === existing.metadata.ino &&
-            confirmed.metadata.mtimeMs === existing.metadata.mtimeMs &&
-            isStaleQuotaLock(confirmed)
-          ) {
-            await unlink(lockPath).catch((unlinkError) => {
-              if (!isMissing(unlinkError)) throw unlinkError;
-            });
-            continue;
+      if (isAlreadyExists(error)) {
+        try {
+          const existing = await readQuotaLock(lockPath);
+          if (existing !== null && isStaleQuotaLock(existing)) {
+            // Match the checkpoint-store lock discipline: a malformed, live, or
+            // replaced record is never reclaimed. The second read narrows the
+            // stale-owner race before the exclusive-create retry below.
+            const confirmed = await readQuotaLock(lockPath);
+            if (
+              confirmed !== null &&
+              confirmed.record.nonce === existing.record.nonce &&
+              confirmed.metadata.ino === existing.metadata.ino &&
+              confirmed.metadata.mtimeMs === existing.metadata.mtimeMs &&
+              isStaleQuotaLock(confirmed)
+            ) {
+              await unlink(lockPath).catch((unlinkError) => {
+                if (!isMissing(unlinkError)) throw unlinkError;
+              });
+              continue;
+            }
           }
-        }
-      } catch (metadataError) {
-        if (!isMissing(metadataError) && !(metadataError instanceof SyntaxError)) {
-          throw new BlueprintPlanReferenceStoreError(
-            'PLAN_REFERENCE_IO',
-            'Plan reference storage is unavailable.',
-          );
+        } catch (metadataError) {
+          if (
+            !isMissing(metadataError) &&
+            !(metadataError instanceof SyntaxError) &&
+            !isRetryableQuotaLockError(metadataError)
+          ) {
+            throw new BlueprintPlanReferenceStoreError(
+              'PLAN_REFERENCE_IO',
+              'Plan reference storage is unavailable.',
+            );
+          }
         }
       }
       if (Date.now() >= deadline) {

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -29,6 +29,9 @@ commit history and downloadable artifacts, see
 - Hardened Codex launcher updates with bounded descriptor reads, caller-owned
   path validation, symlink-safe atomic writes, permission preservation, and
   stale-target content and identity checks.
+- Stabilized blueprint plan-reference quota locking under Windows I/O
+  contention by retrying bounded transient lock errors and extending the wait
+  from 5 to 15 seconds, without weakening fail-closed storage errors.
 - Updated compatible patch/minor dependencies across Discord REST, HTTP,
   validation, testing, and documentation tooling. Dependabot now keeps major
   and known Node-floor/toolchain migrations in dedicated review increments.


### PR DESCRIPTION
## Summary
- retry only Windows `EACCES`, `EBUSY`, and `EPERM` failures at the plan-reference quota lock boundary
- extend the bounded lock deadline from 5 to 15 seconds for high-cardinality scans under runner/antivirus contention
- keep all non-lock and non-transient storage errors fail closed as `PLAN_REFERENCE_IO`

## Evidence
PR #39 Windows 24 initially returned `PLAN_REFERENCE_IO` instead of deterministic quota at the 256-record boundary (job 99266712551); its exact rerun passed. Isolated Windows repeated 20/20, but full core reproduced the failure. Increasing only the timeout did not fix that reproduction, showing an immediate transient lock-path error. The bounded Windows-only retry plus deadline change made the same full core run pass.

## Verification
- `pnpm --filter @discord-mcp/core exec vitest run src/tools/guild/_lib/blueprint.plan-reference-store.test.ts` (8 passed, 1 platform skip)
- `pnpm --filter @discord-mcp/core test` (1259 passed, 4 skipped; catalog 3 passed)
- `pnpm --filter @discord-mcp/core typecheck`
- `pnpm exec biome check packages/mcp-core/src/tools/guild/_lib/blueprint.plan-reference-store.ts`
- `git diff --check`