### PR TITLE
fix: migrate message pin routes

### DIFF
--- a/packages/mcp-core/src/server.result-bytes.report.json
+++ b/packages/mcp-core/src/server.result-bytes.report.json
@@ -58,6 +58,19 @@
       "budgetBytes": 256000
     },
     {
+      "tool": "messages_list_pins",
+      "resultClass": "paginated_collection",
+      "budgetClass": "messages",
+      "inputShape": "maximum",
+      "itemCount": 50,
+      "contentBytes": 103573,
+      "structuredContentBytes": 110162,
+      "totalSerializedBytes": 213784,
+      "duplicatedFieldBytes": 100000,
+      "classBudgetBytes": 768000,
+      "budgetBytes": 500000
+    },
+    {
       "tool": "messages_read",
       "resultClass": "paginated_collection",
       "budgetClass": "messages",
@@ -66,19 +79,6 @@
       "contentBytes": 103514,
       "structuredContentBytes": 108516,
       "totalSerializedBytes": 212079,
-      "duplicatedFieldBytes": 100000,
-      "classBudgetBytes": 768000,
-      "budgetBytes": 500000
-    },
-    {
-      "tool": "messages_list_pins",
-      "resultClass": "paginated_collection",
-      "budgetClass": "messages",
-      "inputShape": "maximum",
-      "itemCount": 50,
-      "contentBytes": 103573,
-      "structuredContentBytes": 108155,
-      "totalSerializedBytes": 211777,
       "duplicatedFieldBytes": 100000,
       "classBudgetBytes": 768000,
       "budgetBytes": 500000

--- a/packages/mcp-core/src/server.result-bytes.test.ts
+++ b/packages/mcp-core/src/server.result-bytes.test.ts
@@ -198,8 +198,14 @@ describe('MCP result byte regression evidence', () => {
         const limit = Math.min(Number(url.searchParams.get('limit') ?? 1), 1000);
         return HttpResponse.json(Array.from({ length: limit }, (_, i) => memberFixture(i + 1)));
       }),
-      http.get('https://discord.com/api/v10/channels/:channelId/pins', () =>
-        HttpResponse.json(Array.from({ length: 50 }, (_, index) => messageFixture(index + 201))),
+      http.get('https://discord.com/api/v10/channels/:channelId/messages/pins', () =>
+        HttpResponse.json({
+          items: Array.from({ length: 50 }, (_, index) => ({
+            pinned_at: `2026-04-30T12:${String(59 - index).padStart(2, '0')}:00.000Z`,
+            message: messageFixture(index + 201),
+          })),
+          has_more: true,
+        }),
       ),
     );
     const rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token');

--- a/packages/mcp-core/src/tools/messages/list_pins.test.ts
+++ b/packages/mcp-core/src/tools/messages/list_pins.test.ts
@@ -9,20 +9,66 @@ import '../../container.js';
 const DISCORD_API = 'https://discord.com/api/v10';
 
 describe('messages_list_pins', () => {
-  it('returns pinned messages with content wrapped', async () => {
+  it('GETs the paginated pins route and returns continuation metadata', async () => {
+    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaa');
+    const before = '2026-04-29T12:00:00.000Z';
+    server.use(
+      http.get(`${DISCORD_API}/channels/:channelId/messages/pins`, ({ request, params }) => {
+        const url = new URL(request.url);
+        expect(params.channelId).toBe('111122223333444401');
+        expect(url.searchParams.get('limit')).toBe('2');
+        expect(url.searchParams.get('before')).toBe(before);
+        return HttpResponse.json({
+          has_more: true,
+          items: [
+            {
+              pinned_at: '2026-04-28T12:00:00.000Z',
+              message: {
+                id: '999000999000999001',
+                channel_id: params.channelId,
+                content: 'pinned welcome',
+                author: { id: '111122223333444401', username: 'bot', global_name: 'Bot' },
+                timestamp: '2026-04-28T11:00:00.000Z',
+              },
+            },
+          ],
+        });
+      }),
+    );
+    const T = messagesListPins;
+    const t = new T(
+      { name: 'messages_list_pins', path: 'inline', root: 'inline', store: null as never },
+      { name: 'messages_list_pins', enabled: true },
+    );
+    const r = (await t.run(
+      { channel_id: '111122223333444401', before, limit: 2 },
+      { signal: new AbortController().signal },
+    )) as {
+      isError: boolean;
+      content: Array<{ text: string }>;
+      structuredContent: {
+        pins: Array<{ pinned_at: string }>;
+        count: number;
+        has_more: boolean;
+        next_before?: string;
+      };
+    };
+    expect(r.isError).toBe(false);
+    expect(r.structuredContent.count).toBe(1);
+    expect(r.structuredContent.has_more).toBe(true);
+    expect(r.structuredContent.pins[0]?.pinned_at).toBe('2026-04-28T12:00:00.000Z');
+    expect(r.structuredContent.next_before).toBe('2026-04-28T12:00:00.000Z');
+    expect(r.content[0]?.text).toMatch(/<untrusted_discord_messages/);
+  });
+
+  it('omits next_before for an empty page', async () => {
     container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaa');
     server.use(
-      http.get(`${DISCORD_API}/channels/:channelId/pins`, async ({ params }) =>
-        HttpResponse.json([
-          {
-            id: '999000999000999001',
-            channel_id: params.channelId,
-            content: 'pinned welcome',
-            author: { id: '111122223333444401', username: 'bot', global_name: 'Bot' },
-            timestamp: '2026-04-28T12:00:00.000000+00:00',
-          },
-        ]),
-      ),
+      http.get(`${DISCORD_API}/channels/:channelId/messages/pins`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(Object.fromEntries(url.searchParams)).toEqual({ limit: '50' });
+        return HttpResponse.json({ items: [], has_more: false });
+      }),
     );
     const T = messagesListPins;
     const t = new T(
@@ -32,13 +78,8 @@ describe('messages_list_pins', () => {
     const r = (await t.run(
       { channel_id: '111122223333444401' },
       { signal: new AbortController().signal },
-    )) as {
-      isError: boolean;
-      content: Array<{ text: string }>;
-      structuredContent: { pins: unknown[]; count: number };
-    };
-    expect(r.isError).toBe(false);
-    expect(r.structuredContent.count).toBe(1);
-    expect(r.content[0]?.text).toMatch(/<untrusted_discord_messages/);
+    )) as { structuredContent: { has_more: boolean; next_before?: string } };
+    expect(r.structuredContent.has_more).toBe(false);
+    expect(r.structuredContent.next_before).toBeUndefined();
   });
 });

--- a/packages/mcp-core/src/tools/messages/list_pins.ts
+++ b/packages/mcp-core/src/tools/messages/list_pins.ts
@@ -14,6 +14,16 @@ interface RawPinnedMessage {
   timestamp: string;
 }
 
+interface RawPinnedItem {
+  pinned_at: string;
+  message: RawPinnedMessage;
+}
+
+interface RawPinnedList {
+  items: RawPinnedItem[];
+  has_more: boolean;
+}
+
 export default defineTool({
   name: 'messages_list_pins',
   category: 'messages',
@@ -26,10 +36,24 @@ export default defineTool({
     '**When NOT to use**:',
     '- Reading recent activity → use `messages_read`.',
     '',
-    '**Returns**: `{pins:[{message_id, author_id, author_name, content, timestamp}], count, channel_id}`. Structured pin fields remain raw Discord data; the human-readable MCP `content` response fences message text.',
+    "**Pagination**: pass `before` (ISO 8601 timestamp from a prior `pinned_at`) and `limit` (1-50). When `has_more` is true, `next_before` is the last item's `pinned_at` for the next page.",
+    '',
+    '**Returns**: `{pins:[{message_id, author_id, author_name, content, timestamp, pinned_at}], has_more, next_before?, count, channel_id}`. Structured pin fields remain raw Discord data; the human-readable MCP `content` response fences message text.',
   ].join('\n'),
   inputSchema: {
     channel_id: ChannelId.describe('Channel to inspect'),
+    before: z
+      .string()
+      .datetime({ offset: true })
+      .optional()
+      .describe('ISO 8601 timestamp; return pins created before this'),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(50)
+      .describe('Maximum pins to fetch (1-50, default 50)'),
   },
   outputSchema: {
     pins: z.array(
@@ -39,8 +63,11 @@ export default defineTool({
         author_name: z.string(),
         content: z.string(),
         timestamp: z.string(),
+        pinned_at: z.string().datetime({ offset: true }),
       }),
     ),
+    has_more: z.boolean(),
+    next_before: z.string().datetime({ offset: true }).optional(),
     count: z.number().int(),
     channel_id: ChannelId,
   },
@@ -52,18 +79,21 @@ export default defineTool({
   },
   idempotent: true,
   handler: async (args) => {
-    const raw = (await container.rest.get(
-      Routes.channelPins(args.channel_id),
-    )) as RawPinnedMessage[];
-    const pins = raw.map((m) => ({
+    const query = new URLSearchParams({ limit: String(args.limit ?? 50) });
+    if (args.before !== undefined) query.set('before', args.before);
+    const raw = (await container.rest.get(Routes.channelMessagesPins(args.channel_id), {
+      query,
+    })) as RawPinnedList;
+    const pins = raw.items.map(({ message: m, pinned_at }) => ({
       message_id: m.id,
       author_id: m.author.id,
       author_name: m.author.global_name ?? m.author.username,
       content: m.content,
       timestamp: m.timestamp,
+      pinned_at,
     }));
     const wrappedText = wrapMessages(
-      raw.map((m) => ({
+      raw.items.map(({ message: m }) => ({
         id: m.id,
         author: m.author.global_name ?? m.author.username,
         content: m.content,
@@ -72,7 +102,15 @@ export default defineTool({
     );
     return dualResult({
       text: wrappedText,
-      data: { pins, count: pins.length, channel_id: args.channel_id },
+      data: {
+        pins,
+        has_more: raw.has_more,
+        ...(raw.has_more && pins.length > 0
+          ? { next_before: pins[pins.length - 1]!.pinned_at }
+          : {}),
+        count: pins.length,
+        channel_id: args.channel_id,
+      },
     });
   },
 });

--- a/packages/mcp-core/src/tools/messages/pin.test.ts
+++ b/packages/mcp-core/src/tools/messages/pin.test.ts
@@ -12,7 +12,7 @@ describe('messages_pin', () => {
   it('PUTs to pins endpoint and returns pinned:true', async () => {
     container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaa');
     server.use(
-      http.put(`${DISCORD_API}/channels/:channelId/pins/:messageId`, async () => {
+      http.put(`${DISCORD_API}/channels/:channelId/messages/pins/:messageId`, async () => {
         return new HttpResponse(null, { status: 204 });
       }),
     );

--- a/packages/mcp-core/src/tools/messages/pin.ts
+++ b/packages/mcp-core/src/tools/messages/pin.ts
@@ -14,9 +14,6 @@ export default defineTool({
     '**When to use**:',
     '- Highlight a community announcement / FAQ in the channel.',
     '',
-    '**When NOT to use**:',
-    '- Channel already has 50 pins (Discord limit) - call returns 400.',
-    '',
     '**Returns**: `{pinned, channel_id, message_id}`.',
   ].join('\n'),
   inputSchema: {
@@ -41,7 +38,7 @@ export default defineTool({
     openWorldHint: true,
   },
   handler: async (args) => {
-    await container.rest.put(Routes.channelPin(args.channel_id, args.message_id), {
+    await container.rest.put(Routes.channelMessagesPin(args.channel_id, args.message_id), {
       reason: args.audit_reason,
     });
     return dualResult({

--- a/packages/mcp-core/src/tools/messages/unpin.test.ts
+++ b/packages/mcp-core/src/tools/messages/unpin.test.ts
@@ -13,7 +13,7 @@ describe('messages_unpin', () => {
     container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaa');
     server.use(
       http.delete(
-        `${DISCORD_API}/channels/:channelId/pins/:messageId`,
+        `${DISCORD_API}/channels/:channelId/messages/pins/:messageId`,
         async () => new HttpResponse(null, { status: 204 }),
       ),
     );

--- a/packages/mcp-core/src/tools/messages/unpin.ts
+++ b/packages/mcp-core/src/tools/messages/unpin.ts
@@ -41,7 +41,7 @@ export default defineTool({
     openWorldHint: true,
   },
   handler: async (args) => {
-    await container.rest.delete(Routes.channelPin(args.channel_id, args.message_id), {
+    await container.rest.delete(Routes.channelMessagesPin(args.channel_id, args.message_id), {
       reason: args.audit_reason,
     });
     return dualResult({

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -13,6 +13,8 @@ commit history and downloadable artifacts, see
 
 - Added resumable `audit_log_get` pages through an optional `before` cursor and
   `oldest_id` continuation marker.
+- Migrated message pin list, pin, and unpin calls off Discord's deprecated
+  routes; pin listing now exposes timestamp pagination and `has_more`.
 - Hardened network and parsing boundaries found by the first CodeQL baseline:
   bot credentials can no longer follow a remote `DISCORD_API_BASE_URL`, release
   checks validate the exact GitHub repository path, npm update checks use the


### PR DESCRIPTION
## Summary
- migrate list/pin/unpin off Discord's deprecated `/channels/{id}/pins` routes to `/channels/{id}/messages/pins`
- add list pagination with ISO8601 `before`, limit 1-50/default 50, `pinned_at`, `has_more`, and `next_before`
- preserve existing pin fields, audit reasons, write receipts, access contracts, and untrusted-content fencing
- update deterministic result-byte evidence for the current response shape (50 pins: 213,784 bytes, under 500,000)
- remove the obsolete 50-total-pins warning and keep an internal fallback for direct handler calls outside schema defaulting

Official Discord docs: https://docs.discord.com/developers/resources/message#Get%20Channel%20Pins

## Verification
- list/pin/unpin/report tests: 5 passed
- `pnpm --filter @discord-mcp/core build`
- `pnpm --filter @discord-mcp/core test` (1262 passed, 4 skipped; catalog 3 passed)
- `pnpm --filter @discord-mcp/core typecheck`
- small-model lifecycle contract tests: 43 passed (not a live model campaign claim)
- `pnpm --filter site build` (303 pages; generated pin docs and navigation verified)
- Biome and `git diff --check`

Relates #23