### PR TITLE
feat: add message scan continuation markers

### DIFF
--- a/packages/mcp-core/src/server.result-bytes.report.json
+++ b/packages/mcp-core/src/server.result-bytes.report.json
@@ -38,8 +38,8 @@
       "inputShape": "maximum",
       "itemCount": 100,
       "contentBytes": 206816,
-      "structuredContentBytes": 216177,
-      "totalSerializedBytes": 423042,
+      "structuredContentBytes": 216259,
+      "totalSerializedBytes": 423124,
       "duplicatedFieldBytes": 200000,
       "classBudgetBytes": 768000,
       "budgetBytes": 500000
@@ -90,8 +90,8 @@
       "inputShape": "default",
       "itemCount": 50,
       "contentBytes": 103514,
-      "structuredContentBytes": 108125,
-      "totalSerializedBytes": 211688,
+      "structuredContentBytes": 108207,
+      "totalSerializedBytes": 211770,
       "duplicatedFieldBytes": 100000,
       "classBudgetBytes": 768000,
       "budgetBytes": 500000
@@ -123,6 +123,19 @@
       "budgetBytes": 768000
     },
     {
+      "tool": "messages_search_recent",
+      "resultClass": "paginated_collection",
+      "budgetClass": "messages",
+      "inputShape": "small",
+      "itemCount": 1,
+      "contentBytes": 2287,
+      "structuredContentBytes": 2325,
+      "totalSerializedBytes": 4661,
+      "duplicatedFieldBytes": 2000,
+      "classBudgetBytes": 768000,
+      "budgetBytes": 500000
+    },
+    {
       "tool": "messages_read",
       "resultClass": "paginated_collection",
       "budgetClass": "messages",
@@ -131,19 +144,6 @@
       "contentBytes": 2287,
       "structuredContentBytes": 2291,
       "totalSerializedBytes": 4627,
-      "duplicatedFieldBytes": 2000,
-      "classBudgetBytes": 768000,
-      "budgetBytes": 500000
-    },
-    {
-      "tool": "messages_search_recent",
-      "resultClass": "paginated_collection",
-      "budgetClass": "messages",
-      "inputShape": "small",
-      "itemCount": 1,
-      "contentBytes": 2287,
-      "structuredContentBytes": 2243,
-      "totalSerializedBytes": 4579,
       "duplicatedFieldBytes": 2000,
       "classBudgetBytes": 768000,
       "budgetBytes": 500000

--- a/packages/mcp-core/src/server.result-bytes.test.ts
+++ b/packages/mcp-core/src/server.result-bytes.test.ts
@@ -281,10 +281,17 @@ describe('MCP result byte regression evidence', () => {
         channel_id: CHANNEL_ID,
         limit: 1,
         before: '999000999000990001',
-        after: '999000999000990002',
       },
     });
     expect(seenCursors.messageBefore).toBe('999000999000990001');
+    await client.callTool({
+      name: 'messages_read',
+      arguments: {
+        channel_id: CHANNEL_ID,
+        limit: 1,
+        after: '999000999000990002',
+      },
+    });
     expect(seenCursors.messageAfter).toBe('999000999000990002');
     for (const limit of [1, 50, 100]) {
       const result = await client.callTool({

--- a/packages/mcp-core/src/tools/messages/read.test.ts
+++ b/packages/mcp-core/src/tools/messages/read.test.ts
@@ -1,5 +1,7 @@
+import { server } from '@discord-mcp/server-mocks';
 import { REST } from '@discordjs/rest';
 import { container } from '@sapphire/pieces';
+import { HttpResponse, http } from 'msw';
 import { describe, expect, it } from 'vitest';
 import messagesRead from './read.js';
 import '../../container.js';
@@ -42,5 +44,36 @@ describe('messages_read', () => {
     const schema = z.object(t.inputSchema);
     expect(schema.safeParse({ channel_id: '112233445566778899', limit: 0 }).success).toBe(false);
     expect(schema.safeParse({ channel_id: '112233445566778899', limit: 101 }).success).toBe(false);
+  });
+
+  it('applies the default limit and rejects conflicting cursors', async () => {
+    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token');
+    server.use(
+      http.get('https://discord.com/api/v10/channels/:channelId/messages', ({ request }) => {
+        expect(Object.fromEntries(new URL(request.url).searchParams)).toEqual({ limit: '50' });
+        return HttpResponse.json([]);
+      }),
+    );
+    const T = messagesRead;
+    const t = new T(
+      { name: 'messages_read', path: 'inline', root: 'inline', store: null as never },
+      { name: 'messages_read', enabled: true },
+    );
+    const result = (await t.run(
+      { channel_id: '112233445566778899' },
+      { signal: new AbortController().signal },
+    )) as { structuredContent: { count: number } };
+    expect(result.structuredContent.count).toBe(0);
+
+    await expect(
+      t.run(
+        {
+          channel_id: '112233445566778899',
+          before: '999000999000000099',
+          after: '999000999000000001',
+        },
+        { signal: new AbortController().signal },
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_FAILED' });
   });
 });

--- a/packages/mcp-core/src/tools/messages/read.ts
+++ b/packages/mcp-core/src/tools/messages/read.ts
@@ -1,6 +1,7 @@
 import { container } from '@sapphire/pieces';
 import { Routes } from 'discord-api-types/v10';
 import { z } from 'zod';
+import { ValidationError } from '../../errors/client.js';
 import { defineTool } from '../_lib/defineTool.js';
 import { dualResult } from '../_lib/response.js';
 import { ChannelId, MessageId, UserId } from '../_lib/snowflake.js';
@@ -40,8 +41,12 @@ export default defineTool({
       .max(100)
       .default(50)
       .describe('Messages to fetch (1-100, default 50)'),
-    before: MessageId.optional().describe('Get messages before this ID (older)'),
-    after: MessageId.optional().describe('Get messages after this ID (newer)'),
+    before: MessageId.optional().describe(
+      'Get messages before this ID (older); mutually exclusive with after',
+    ),
+    after: MessageId.optional().describe(
+      'Get messages after this ID (newer); mutually exclusive with before',
+    ),
   },
   outputSchema: {
     messages: z.array(
@@ -67,7 +72,12 @@ export default defineTool({
   },
   idempotent: true,
   handler: async (args) => {
-    const query = new URLSearchParams({ limit: String(args.limit) });
+    if (args.before !== undefined && args.after !== undefined) {
+      throw new ValidationError([
+        { path: 'before', message: 'before and after are mutually exclusive', code: 'custom' },
+      ]);
+    }
+    const query = new URLSearchParams({ limit: String(args.limit ?? 50) });
     if (args.before !== undefined) query.set('before', args.before);
     if (args.after !== undefined) query.set('after', args.after);
     const raw = (await container.rest.get(Routes.channelMessages(args.channel_id), {

--- a/packages/mcp-core/src/tools/messages/search_recent.test.ts
+++ b/packages/mcp-core/src/tools/messages/search_recent.test.ts
@@ -1,28 +1,123 @@
+import { server } from '@discord-mcp/server-mocks';
 import { REST } from '@discordjs/rest';
 import { container } from '@sapphire/pieces';
+import { HttpResponse, http } from 'msw';
 import { describe, expect, it } from 'vitest';
 import messagesSearchRecent from './search_recent.js';
 import '../../container.js';
 
 describe('messages_search_recent', () => {
-  it('filters default-handler messages by substring', async () => {
-    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaa');
-    // Default handler returns "message {n} content" for n in 1..3 with limit=3.
+  function createTool() {
     const T = messagesSearchRecent;
-    const t = new T(
+    return new T(
       { name: 'messages_search_recent', path: 'inline', root: 'inline', store: null as never },
       { name: 'messages_search_recent', enabled: true },
     );
+  }
+
+  it('filters default-handler messages by substring', async () => {
+    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaa');
+    // Default handler returns "message {n} content" for n in 1..3 with limit=3.
+    const t = createTool();
     const r = (await t.run(
       { channel_id: '111122223333444401', query: 'message 2', limit: 3 },
       { signal: new AbortController().signal },
     )) as {
       isError: boolean;
-      structuredContent: { matches: Array<{ content: string }>; scanned_count: number };
+      structuredContent: {
+        matches: Array<{ content: string }>;
+        scanned_count: number;
+        oldest_scanned_id?: string;
+        newest_scanned_id?: string;
+      };
     };
     expect(r.isError).toBe(false);
     expect(r.structuredContent.scanned_count).toBe(3);
+    expect(r.structuredContent.oldest_scanned_id).toBe('100000101795323141');
+    expect(r.structuredContent.newest_scanned_id).toBe('100000101795321187');
     expect(r.structuredContent.matches.length).toBe(1);
     expect(r.structuredContent.matches[0]?.content).toContain('message 2');
+  });
+
+  it('returns scan boundaries even when the page has no matches', async () => {
+    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaa');
+    server.use(
+      http.get('https://discord.com/api/v10/channels/:channelId/messages', () =>
+        HttpResponse.json([
+          {
+            id: '999000999000000003',
+            channel_id: '111122223333444401',
+            content: 'alpha',
+            author: { id: '999000999000000013', username: 'user3' },
+            timestamp: '2026-04-28T12:03:00.000Z',
+            edited_timestamp: null,
+          },
+          {
+            id: '999000999000000002',
+            channel_id: '111122223333444401',
+            content: 'beta',
+            author: { id: '999000999000000012', username: 'user2' },
+            timestamp: '2026-04-28T12:02:00.000Z',
+            edited_timestamp: null,
+          },
+        ]),
+      ),
+    );
+    const r = (await createTool().run(
+      { channel_id: '111122223333444401', query: 'missing', limit: 2 },
+      { signal: new AbortController().signal },
+    )) as { structuredContent: Record<string, unknown> };
+    expect(r.structuredContent.matches).toEqual([]);
+    expect(r.structuredContent.scanned_count).toBe(2);
+    expect(r.structuredContent.newest_scanned_id).toBe('999000999000000003');
+    expect(r.structuredContent.oldest_scanned_id).toBe('999000999000000002');
+  });
+
+  it('omits scan boundaries for an empty page', async () => {
+    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaa');
+    server.use(
+      http.get('https://discord.com/api/v10/channels/:channelId/messages', ({ request }) => {
+        expect(Object.fromEntries(new URL(request.url).searchParams)).toEqual({ limit: '100' });
+        return HttpResponse.json([]);
+      }),
+    );
+    const r = (await createTool().run(
+      { channel_id: '111122223333444401', query: 'missing' },
+      { signal: new AbortController().signal },
+    )) as { structuredContent: Record<string, unknown> };
+    expect(r.structuredContent.scanned_count).toBe(0);
+    expect(r.structuredContent.oldest_scanned_id).toBeUndefined();
+    expect(r.structuredContent.newest_scanned_id).toBeUndefined();
+  });
+
+  it.each([
+    { field: 'before', value: '999000999000000099' },
+    { field: 'after', value: '999000999000000001' },
+  ] as const)('propagates the $field cursor to Discord', async ({ field, value }) => {
+    container.rest = new REST({ version: '10', makeRequest: fetch }).setToken('fake-token-aaaaaa');
+    server.use(
+      http.get('https://discord.com/api/v10/channels/:channelId/messages', ({ request }) => {
+        expect(new URL(request.url).searchParams.get(field)).toBe(value);
+        return HttpResponse.json([]);
+      }),
+    );
+    await createTool().run(
+      { channel_id: '111122223333444401', query: 'missing', [field]: value },
+      { signal: new AbortController().signal },
+    );
+  });
+
+  it('rejects simultaneous before and after cursors before Discord I/O', async () => {
+    await expect(
+      createTool().run(
+        {
+          channel_id: '111122223333444401',
+          query: 'missing',
+          before: '999000999000000099',
+          after: '999000999000000001',
+        },
+        { signal: new AbortController().signal },
+      ),
+    ).rejects.toMatchObject({ code: 'VALIDATION_FAILED' });
   });
 });

--- a/packages/mcp-core/src/tools/messages/search_recent.ts
+++ b/packages/mcp-core/src/tools/messages/search_recent.ts
@@ -1,6 +1,7 @@
 import { container } from '@sapphire/pieces';
 import { Routes } from 'discord-api-types/v10';
 import { z } from 'zod';
+import { ValidationError } from '../../errors/client.js';
 import { defineTool } from '../_lib/defineTool.js';
 import { dualResult } from '../_lib/response.js';
 import { ChannelId, MessageId, UserId } from '../_lib/snowflake.js';
@@ -29,7 +30,7 @@ export default defineTool({
     '',
     '**Example**: `{channel_id:"111122223333444401", query:"deploy", limit:100}`',
     '',
-    '**Returns**: `{matches:[…], scanned_count, channel_id, query}`. Structured matches remain raw Discord data; the human-readable MCP `content` response fences matched message text.',
+    '**Returns**: `{matches:[…], scanned_count, oldest_scanned_id?, newest_scanned_id?, channel_id, query}`. Structured matches remain raw Discord data; the human-readable MCP `content` response fences matched message text. Resume older history with `before: oldest_scanned_id`.',
   ].join('\n'),
   inputSchema: {
     channel_id: ChannelId.describe('Channel to scan'),
@@ -41,8 +42,12 @@ export default defineTool({
       .max(100)
       .default(100)
       .describe('Max recent messages to scan (1-100, default 100). NOT a result cap.'),
-    before: MessageId.optional().describe('Scan window: messages before this ID (older)'),
-    after: MessageId.optional().describe('Scan window: messages after this ID (newer)'),
+    before: MessageId.optional().describe(
+      'Scan window: messages before this ID (older); mutually exclusive with after',
+    ),
+    after: MessageId.optional().describe(
+      'Scan window: messages after this ID (newer); mutually exclusive with before',
+    ),
   },
   outputSchema: {
     matches: z.array(
@@ -55,6 +60,8 @@ export default defineTool({
       }),
     ),
     scanned_count: z.number().int(),
+    oldest_scanned_id: MessageId.optional(),
+    newest_scanned_id: MessageId.optional(),
     channel_id: ChannelId,
     query: z.string(),
   },
@@ -66,7 +73,12 @@ export default defineTool({
   },
   idempotent: true,
   handler: async (args) => {
-    const query = new URLSearchParams({ limit: String(args.limit) });
+    if (args.before !== undefined && args.after !== undefined) {
+      throw new ValidationError([
+        { path: 'before', message: 'before and after are mutually exclusive', code: 'custom' },
+      ]);
+    }
+    const query = new URLSearchParams({ limit: String(args.limit ?? 100) });
     if (args.before !== undefined) query.set('before', args.before);
     if (args.after !== undefined) query.set('after', args.after);
 
@@ -97,6 +109,12 @@ export default defineTool({
       data: {
         matches,
         scanned_count: raw.length,
+        ...(raw.length > 0
+          ? {
+              oldest_scanned_id: raw[raw.length - 1]!.id,
+              newest_scanned_id: raw[0]!.id,
+            }
+          : {}),
         channel_id: args.channel_id,
         query: args.query,
       },

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -15,6 +15,8 @@ commit history and downloadable artifacts, see
   `oldest_id` continuation marker.
 - Migrated message pin list, pin, and unpin calls off Discord's deprecated
   routes; pin listing now exposes timestamp pagination and `has_more`.
+- Added scanned-page boundary IDs to `messages_search_recent` so zero-match
+  pages can still continue through older channel history without gaps.
 - Hardened network and parsing boundaries found by the first CodeQL baseline:
   bot credentials can no longer follow a remote `DISCORD_API_BASE_URL`, release
   checks validate the exact GitHub repository path, npm update checks use the


### PR DESCRIPTION
## Summary
- add `oldest_scanned_id` and `newest_scanned_id` to `messages_search_recent`, derived from the full scanned page even when there are zero matches
- let callers resume older history with `before: oldest_scanned_id`; empty pages omit both markers
- enforce Discord's mutually exclusive `before`/`after` contract before I/O for both `messages_read` and `messages_search_recent`
- keep direct-handler defaults deterministic (`messages_read` 50, search 100)
- replace the invalid dual-cursor report probe with separate valid requests and update exact byte evidence (+82 bytes per search page)

Discord documents channel messages newest-to-oldest and before/after as mutually exclusive: https://docs.discord.com/developers/resources/message#Get%20Channel%20Messages

## Compatibility
All output markers are additive and optional. Existing result fields and untrusted-message fencing remain unchanged; only previously invalid simultaneous cursors now fail with `VALIDATION_FAILED`.

## Verification
- read/search/report targeted tests: 10 passed
- `pnpm --filter @discord-mcp/core build`
- `pnpm --filter @discord-mcp/core test` (1267 passed, 4 skipped; catalog 3 passed)
- `pnpm --filter @discord-mcp/core typecheck`
- small-model lifecycle contract tests: 43 passed (not a live model campaign claim)
- `pnpm --filter site build` (303 pages; generated docs/navigation verified)
- Biome and `git diff --check`

Relates #23